### PR TITLE
config: enable strict TypeScript and include src-shared in tsconfig

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,11 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
+  "include": [
+    "electron.vite.config.*",
+    "src/main/**/*",
+    "src/preload/**/*",
+    "src-shared/**/*"
+  ],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"]

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -4,14 +4,13 @@
     "src/renderer/src/env.d.ts",
     "src/renderer/src/**/*",
     "src/renderer/src/**/*.svelte",
-    "src/preload/*.d.ts"
+    "src/preload/*.d.ts",
+    "src-shared/**/*"
   ],
   "compilerOptions": {
     "verbatimModuleSyntax": true,
     "useDefineForClassFields": true,
-    "strict": false,
-    "allowJs": true,
-    "checkJs": true,
+    "strict": true,
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   }
 }


### PR DESCRIPTION
Closes #2 — Enables strict mode, removes allowJs/checkJs, and adds src-shared to both tsconfig.node.json and tsconfig.web.json so shared types and the StorageAdapter are included in type checking.