### PR TITLE
config: configure electron-builder for Windows and GitHub Releases

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,44 +1,29 @@
-appId: com.electron.app
-productName: quilltorium
+appId: com.andificus.quilltorium
+productName: Quilltorium
 directories:
   buildResources: build
 files:
   - '!**/.vscode/*'
   - '!src/*'
+  - '!src-shared/*'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
   - '!svelte.config.mjs'
   - '!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+  - '!DEV_NOTES.md'
+  - '!PROJECT_PLAN.md'
 asarUnpack:
   - resources/**
 win:
-  executableName: quilltorium
+  executableName: Quilltorium
+  artifactName: ${productName}-${version}-setup.${ext}
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
-mac:
-  entitlementsInherit: build/entitlements.mac.plist
-  extendInfo:
-    - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
-    - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
-    - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
-dmg:
-  artifactName: ${name}-${version}.${ext}
-linux:
-  target:
-    - AppImage
-    - snap
-    - deb
-  maintainer: electronjs.org
-  category: Utility
-appImage:
-  artifactName: ${name}-${version}.${ext}
-npmRebuild: false
 publish:
-  provider: generic
-  url: https://example.com/auto-updates
+  provider: github
+  owner: andificus
+  repo: Quilltorium


### PR DESCRIPTION
Closes #5 — Removes macOS and Linux targets, sets Windows-only build, points publish to GitHub Releases under andificus/Quilltorium.