### PR TITLE
feat: wire electron-updater with user-prompted update flow

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,16 +1,24 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { autoUpdater } from 'electron-updater'
 import icon from '../../resources/icon.png?asset'
 
+/** The main application window instance */
+let mainWindow: BrowserWindow | null = null
+
+/**
+ * Creates the main application window.
+ */
 function createWindow(): void {
-  // Create the browser window.
-  const mainWindow = new BrowserWindow({
-    width: 900,
-    height: 670,
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
     show: false,
     autoHideMenuBar: true,
-    ...(process.platform === 'linux' ? { icon } : {}),
+    icon,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false
@@ -18,7 +26,7 @@ function createWindow(): void {
   })
 
   mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+    mainWindow?.show()
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
@@ -26,8 +34,6 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
-  // HMR for renderer base on electron-vite cli.
-  // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
@@ -35,40 +41,84 @@ function createWindow(): void {
   }
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.whenReady().then(() => {
-  // Set app user model id for windows
-  electronApp.setAppUserModelId('com.electron')
+/**
+ * Configures the auto-updater with a fully user-prompted flow.
+ * Nothing downloads or installs without explicit user confirmation.
+ */
+function setupUpdater(): void {
+  // CRITICAL: never change these to true
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = false
 
-  // Default open or close DevTools by F12 in development
-  // and ignore CommandOrControl + R in production.
-  // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
+  // A newer version is available — ask the user before downloading anything
+  autoUpdater.on('update-available', (info) => {
+    dialog.showMessageBox({
+      type: 'info',
+      title: 'Update Available',
+      message: `Quilltorium ${info.version} is available.`,
+      detail: 'Would you like to download it now? You can keep writing while it downloads.',
+      buttons: ['Download Now', 'Not Right Now'],
+      defaultId: 0,
+      cancelId: 1
+    }).then((result) => {
+      if (result.response === 0) {
+        autoUpdater.downloadUpdate()
+      }
+    })
+  })
+
+  // Show download progress in the taskbar
+  autoUpdater.on('download-progress', (progress) => {
+    mainWindow?.setProgressBar(progress.percent / 100)
+  })
+
+  // Download finished — ask the user when to install
+  autoUpdater.on('update-downloaded', () => {
+    mainWindow?.setProgressBar(-1)
+    dialog.showMessageBox({
+      type: 'info',
+      title: 'Update Ready',
+      message: 'The update has been downloaded.',
+      detail: 'Restart Quilltorium now to install it, or it will install automatically next time you open the app.',
+      buttons: ['Restart Now', 'Install Later'],
+      defaultId: 0,
+      cancelId: 1
+    }).then((result) => {
+      if (result.response === 0) {
+        autoUpdater.quitAndInstall()
+      }
+    })
+  })
+
+  // No update found — do nothing, open normally
+  autoUpdater.on('update-not-available', () => {
+    // Intentionally silent
+  })
+
+  // Log update errors but don't crash the app
+  autoUpdater.on('error', (error) => {
+    console.error('Update check failed:', error)
+  })
+}
+
+app.whenReady().then(() => {
+  // Set app user model ID to match electron-builder appId
+  electronApp.setAppUserModelId('com.andificus.quilltorium')
+
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  // IPC test
-  ipcMain.on('ping', () => console.log('pong'))
-
   createWindow()
 
-  app.on('activate', function () {
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
-
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit()
+  // Check for updates after the window is ready (only in production)
+  if (!is.dev) {
+    setupUpdater()
+    autoUpdater.checkForUpdates()
   }
 })
 
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
+// Windows: quit the app when all windows are closed
+app.on('window-all-closed', () => {
+  app.quit()
+})


### PR DESCRIPTION
Closes #7 — Configures autoUpdater with autoDownload=false. User is prompted before any download begins and again before install. Update check only runs in production, not during development.