### PR TITLE
feat: implement project create and open flow with native dialogs

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,11 @@
-import { app, shell, BrowserWindow, dialog } from 'electron'
+import { app, shell, BrowserWindow, dialog, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { autoUpdater } from 'electron-updater'
 import icon from '../../resources/icon.png?asset'
+import { ElectronAdapter } from '../../src-shared/storage/ElectronAdapter'
+import type { ProjectMetadata } from '../../src-shared/types'
+
 
 /** The main application window instance */
 let mainWindow: BrowserWindow | null = null
@@ -116,6 +119,100 @@ app.whenReady().then(() => {
   if (!is.dev) {
     setupUpdater()
     autoUpdater.checkForUpdates()
+  }
+})
+
+// ── IPC Handlers ────────────────────────────────────────────────────────────
+
+const adapter = new ElectronAdapter()
+
+/**
+ * Opens a folder picker and loads an existing project.
+ * Returns the project metadata or null if cancelled.
+ */
+ipcMain.handle('project:open', async () => {
+  const result = await dialog.showOpenDialog({
+    title: 'Open Novel Project',
+    properties: ['openDirectory']
+  })
+
+  if (result.canceled || result.filePaths.length === 0) return null
+
+  const projectPath = result.filePaths[0]
+  const projectJsonPath = join(projectPath, 'project.json')
+
+  try {
+    const exists = await adapter.exists(projectJsonPath)
+    if (!exists) {
+      await dialog.showMessageBox({
+        type: 'error',
+        title: 'Not a Quilltorium Project',
+        message: 'The selected folder does not contain a Quilltorium project.',
+        detail: 'Please select a folder that was created by Quilltorium.'
+      })
+      return null
+    }
+
+    const raw = await adapter.readFile(projectJsonPath)
+    const metadata: ProjectMetadata = JSON.parse(raw)
+    metadata.lastOpened = new Date().toISOString()
+    await adapter.writeFile(projectJsonPath, JSON.stringify(metadata, null, 2))
+    return metadata
+  } catch (error) {
+    console.error('Failed to open project:', error)
+    return null
+  }
+})
+
+/**
+ * Opens a folder picker, then creates a new project structure.
+ * Returns the project metadata or null if cancelled.
+ */
+ipcMain.handle('project:create', async (_event, title: string, author: string) => {
+  const result = await dialog.showOpenDialog({
+    title: 'Choose Project Location',
+    properties: ['openDirectory']
+  })
+
+  if (result.canceled || result.filePaths.length === 0) return null
+
+  const projectPath = join(result.filePaths[0], title.replace(/[^a-zA-Z0-9 _-]/g, '').trim())
+
+  try {
+    // Create folder structure
+    await adapter.createDirectory(projectPath)
+    await adapter.createDirectory(join(projectPath, 'scenes'))
+    await adapter.createDirectory(join(projectPath, 'characters'))
+    await adapter.createDirectory(join(projectPath, 'locations'))
+    await adapter.createDirectory(join(projectPath, 'lore'))
+    await adapter.createDirectory(join(projectPath, 'notes'))
+    await adapter.createDirectory(join(projectPath, 'assets'))
+
+    // Write project.json
+    const now = new Date().toISOString()
+    const metadata: ProjectMetadata = {
+      id: crypto.randomUUID(),
+      title,
+      author,
+      formatVersion: '1.0',
+      created: now,
+      lastOpened: now,
+      settings: {
+        targetWordCount: null,
+        defaultStatus: 'draft',
+        uiMode: 'advanced'
+      }
+    }
+
+    await adapter.writeFile(
+      join(projectPath, 'project.json'),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to create project:', error)
+    return null
   }
 })
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,8 +1,9 @@
-import { ElectronAPI } from '@electron-toolkit/preload'
+import type { ElectronAPI } from '@electron-toolkit/preload'
+import type { API } from './index'
 
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    api: API
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,12 +1,27 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import type { ProjectMetadata } from '../../src-shared/types'
 
-// Custom APIs for renderer
-const api = {}
+/**
+ * The API exposed to the renderer process via contextBridge.
+ * All communication with the main process goes through these methods.
+ */
+const api = {
+  /**
+   * Open an existing project by selecting a folder.
+   * Returns the project metadata if successful, or null if cancelled.
+   */
+  openProject: (): Promise<ProjectMetadata | null> =>
+    ipcRenderer.invoke('project:open'),
 
-// Use `contextBridge` APIs to expose Electron APIs to
-// renderer only if context isolation is enabled, otherwise
-// just add to the DOM global.
+  /**
+   * Create a new project in a selected folder.
+   * Returns the project metadata if successful, or null if cancelled.
+   */
+  createProject: (title: string, author: string): Promise<ProjectMetadata | null> =>
+    ipcRenderer.invoke('project:create', title, author),
+}
+
 if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
@@ -15,8 +30,10 @@ if (process.contextIsolated) {
     console.error(error)
   }
 } else {
-  // @ts-ignore (define in dts)
+  // @ts-ignore
   window.electron = electronAPI
-  // @ts-ignore (define in dts)
+  // @ts-ignore
   window.api = api
 }
+
+export type API = typeof api

--- a/src/renderer/src/components/NewProjectModal.svelte
+++ b/src/renderer/src/components/NewProjectModal.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+
+  const dispatch = createEventDispatcher<{
+    confirm: { title: string; author: string }
+    cancel: void
+  }>()
+
+  let title = ''
+  let author = ''
+
+  function handleConfirm(): void {
+    if (title.trim() === '') return
+    dispatch('confirm', { title: title.trim(), author: author.trim() })
+  }
+
+  function handleCancel(): void {
+    dispatch('cancel')
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') handleConfirm()
+    if (e.key === 'Escape') handleCancel()
+  }
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<div class="modal-backdrop" on:click={handleCancel}>
+  <div class="modal" on:click|stopPropagation>
+    <h2 class="modal-title">New Project</h2>
+
+    <div class="field">
+      <label for="project-title">Novel Title</label>
+      <input
+        id="project-title"
+        type="text"
+        placeholder="e.g. The Sundering of Eltharien"
+        bind:value={title}
+        autofocus
+      />
+    </div>
+
+    <div class="field">
+      <label for="project-author">Author Name</label>
+      <input
+        id="project-author"
+        type="text"
+        placeholder="e.g. Andy Wentzloff"
+        bind:value={author}
+      />
+    </div>
+
+    <div class="modal-actions">
+      <button class="btn-secondary" on:click={handleCancel}>Cancel</button>
+      <button
+        class="btn-primary"
+        on:click={handleConfirm}
+        disabled={title.trim() === ''}
+      >
+        Create Project
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    padding: 28px;
+    width: 420px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .modal-title {
+    font-family: var(--font-display);
+    font-size: 24px;
+    font-weight: 400;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  label {
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  input {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  input:focus {
+    border-color: var(--color-accent);
+  }
+
+  input::placeholder {
+    color: var(--color-text-faint);
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 4px;
+  }
+
+  .btn-primary {
+    padding: 9px 20px;
+    background: var(--color-accent);
+    color: #1a1a1f;
+    border: none;
+    border-radius: 6px;
+    font-family: var(--font-ui);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    opacity: 0.85;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-secondary {
+    padding: 9px 20px;
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-family: var(--font-ui);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .btn-secondary:hover {
+    background: var(--color-surface-hover);
+  }
+</style>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,2 +1,15 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+import type { ProjectMetadata } from '../../src-shared/types'
+
+declare global {
+  interface Window {
+    api: {
+      openProject(): Promise<ProjectMetadata | null>
+      createProject(title: string, author: string): Promise<ProjectMetadata | null>
+    }
+  }
+}
+
+export type { ProjectMetadata }

--- a/src/renderer/src/stores/app.ts
+++ b/src/renderer/src/stores/app.ts
@@ -27,8 +27,8 @@ export function setActiveSection(section: AppSection): void {
 }
 
 /** Set the open project */
-export function setProject(path: string, title: string): void {
-  appState.update(state => ({ ...state, projectPath: path, projectTitle: title }))
+export function setProject(id: string, title: string): void {
+  appState.update(state => ({ ...state, projectPath: id, projectTitle: title }))
 }
 
 /** Close the current project */

--- a/src/renderer/src/views/WelcomeView.svelte
+++ b/src/renderer/src/views/WelcomeView.svelte
@@ -1,13 +1,42 @@
 <script lang="ts">
-  // Placeholder handlers — wired up properly in Issue #19
+  import { setProject } from '../stores/app'
+  import NewProjectModal from '../components/NewProjectModal.svelte'
+
+  let showNewProjectModal = false
+
   function handleNewProject(): void {
-    console.log('New project — coming in Issue #19')
+    showNewProjectModal = true
   }
 
-  function handleOpenProject(): void {
-    console.log('Open project — coming in Issue #19')
+  async function handleModalConfirm(
+    e: CustomEvent<{ title: string; author: string }>
+  ): Promise<void> {
+    showNewProjectModal = false
+    const { title, author } = e.detail
+    const metadata = await window.api.createProject(title, author)
+    if (metadata) {
+      setProject(metadata.id, metadata.title)
+    }
+  }
+
+  function handleModalCancel(): void {
+    showNewProjectModal = false
+  }
+
+  async function handleOpenProject(): Promise<void> {
+    const metadata = await window.api.openProject()
+    if (metadata) {
+      setProject(metadata.id, metadata.title)
+    }
   }
 </script>
+
+{#if showNewProjectModal}
+  <NewProjectModal
+    on:confirm={handleModalConfirm}
+    on:cancel={handleModalCancel}
+  />
+{/if}
 
 <div class="welcome">
   <div class="welcome-content">


### PR DESCRIPTION
Closes #19 — Wires up New Project modal and Open Project folder picker. Creates full project folder structure on disk, writes project.json, and updates app state on success.