### PR TITLE
feat: add recent projects list to welcome screen

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -172,6 +172,7 @@ ipcMain.handle('project:open', async () => {
     metadata.lastOpened = new Date().toISOString()
     await adapter.writeFile(projectJsonPath, JSON.stringify(metadata, null, 2))
     currentProjectPath = projectPath
+    await addRecentProject(projectPath, metadata.title)
     return metadata
   } catch (error) {
     console.error('Failed to open project:', error)
@@ -225,6 +226,7 @@ ipcMain.handle('project:create', async (_event, title: string, author: string) =
     )
 
     currentProjectPath = projectPath
+    await addRecentProject(projectPath, metadata.title)
     return metadata
   } catch (error) {
     console.error('Failed to create project:', error)
@@ -1042,6 +1044,98 @@ ipcMain.handle('locations:update-metadata', async (
   } catch (error) {
     console.error('Failed to update location metadata:', error)
     return false
+  }
+})
+
+// ── Recent Projects ──────────────────────────────────────────────────────────
+
+/** Path to the app-level settings file (outside any project folder) */
+function getAppSettingsPath(): string {
+  return join(app.getPath('userData'), 'app-settings.json')
+}
+
+interface AppSettings {
+  recentProjects: Array<{ path: string; title: string; lastOpened: string }>
+}
+
+/** Read the app settings file */
+async function readAppSettings(): Promise<AppSettings> {
+  try {
+    const settingsPath = getAppSettingsPath()
+    const exists = await adapter.exists(settingsPath)
+    if (!exists) return { recentProjects: [] }
+    const raw = await adapter.readFile(settingsPath)
+    return JSON.parse(raw) as AppSettings
+  } catch {
+    return { recentProjects: [] }
+  }
+}
+
+/** Write the app settings file */
+async function writeAppSettings(settings: AppSettings): Promise<void> {
+  try {
+    await adapter.writeFile(getAppSettingsPath(), JSON.stringify(settings, null, 2))
+  } catch (error) {
+    console.error('Failed to write app settings:', error)
+  }
+}
+
+/** Add or update a project in the recent projects list */
+async function addRecentProject(path: string, title: string): Promise<void> {
+  const settings = await readAppSettings()
+  const now = new Date().toISOString()
+
+  // Remove existing entry for this path if present
+  const filtered = settings.recentProjects.filter(p => p.path !== path)
+
+  // Add to front of list, keep max 10
+  settings.recentProjects = [
+    { path, title, lastOpened: now },
+    ...filtered
+  ].slice(0, 10)
+
+  await writeAppSettings(settings)
+}
+
+/** Get the list of recent projects */
+ipcMain.handle('app:get-recent-projects', async () => {
+  const settings = await readAppSettings()
+  return settings.recentProjects
+})
+
+/** Open a recent project directly by path */
+ipcMain.handle('app:open-recent-project', async (
+  _event,
+  projectPath: string
+): Promise<ProjectMetadata | null> => {
+  const projectJsonPath = join(projectPath, 'project.json')
+
+  try {
+    const exists = await adapter.exists(projectJsonPath)
+    if (!exists) {
+      await dialog.showMessageBox({
+        type: 'error',
+        title: 'Project Not Found',
+        message: 'This project folder could not be found.',
+        detail: 'It may have been moved or deleted. It will be removed from your recent projects list.'
+      })
+      // Remove from recent projects
+      const settings = await readAppSettings()
+      settings.recentProjects = settings.recentProjects.filter(p => p.path !== projectPath)
+      await writeAppSettings(settings)
+      return null
+    }
+
+    const raw = await adapter.readFile(projectJsonPath)
+    const metadata: ProjectMetadata = JSON.parse(raw)
+    metadata.lastOpened = new Date().toISOString()
+    await adapter.writeFile(projectJsonPath, JSON.stringify(metadata, null, 2))
+    currentProjectPath = projectPath
+    await addRecentProject(projectPath, metadata.title)
+    return metadata
+  } catch (error) {
+    console.error('Failed to open recent project:', error)
+    return null
   }
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -76,7 +76,13 @@ const api = {
     locationId: string,
     updates: Partial<LocationMetadata>
   ): Promise<boolean> =>
-    ipcRenderer.invoke('locations:update-metadata', locationId, updates)  
+    ipcRenderer.invoke('locations:update-metadata', locationId, updates),
+    
+  getRecentProjects: (): Promise<Array<{ path: string; title: string; lastOpened: string }>> =>
+    ipcRenderer.invoke('app:get-recent-projects'),
+
+  openRecentProject: (projectPath: string): Promise<ProjectMetadata | null> =>
+    ipcRenderer.invoke('app:open-recent-project', projectPath),
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -37,6 +37,8 @@ declare global {
         locationId: string,
         updates: Partial<LocationMetadata>
       ): Promise<boolean>
+      getRecentProjects(): Promise<Array<{ path: string; title: string; lastOpened: string }>>
+      openRecentProject(projectPath: string): Promise<ProjectMetadata | null>
     }
   }
 }

--- a/src/renderer/src/views/WelcomeView.svelte
+++ b/src/renderer/src/views/WelcomeView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { setProject } from '../stores/app'
   import { loadScenes } from '../stores/scenes'
   import { loadCharacters } from '../stores/characters'
@@ -6,6 +7,19 @@
   import NewProjectModal from '../components/NewProjectModal.svelte'
 
   let showNewProjectModal = false
+  let recentProjects: Array<{ path: string; title: string; lastOpened: string }> = []
+
+  onMount(async () => {
+    recentProjects = await window.api.getRecentProjects()
+  })
+
+  async function openProject(metadata: Awaited<ReturnType<typeof window.api.openProject>>): Promise<void> {
+    if (metadata) {
+      setProject(metadata.id, metadata.title)
+      await Promise.all([loadScenes(), loadCharacters(), loadLocations()])
+      recentProjects = await window.api.getRecentProjects()
+    }
+  }
 
   function handleNewProject(): void {
     showNewProjectModal = true
@@ -17,10 +31,7 @@
     showNewProjectModal = false
     const { title, author } = e.detail
     const metadata = await window.api.createProject(title, author)
-    if (metadata) {
-      setProject(metadata.id, metadata.title)
-      await Promise.all([loadScenes(), loadCharacters(), loadLocations()])
-    }
+    await openProject(metadata)
   }
 
   function handleModalCancel(): void {
@@ -29,10 +40,28 @@
 
   async function handleOpenProject(): Promise<void> {
     const metadata = await window.api.openProject()
+    await openProject(metadata)
+  }
+
+  async function handleOpenRecent(path: string): Promise<void> {
+    const metadata = await window.api.openRecentProject(path)
     if (metadata) {
-      setProject(metadata.id, metadata.title)
-      await Promise.all([loadScenes(), loadCharacters(), loadLocations()])
+      await openProject(metadata)
+    } else {
+      // Project not found — refresh the list
+      recentProjects = await window.api.getRecentProjects()
     }
+  }
+
+  function formatDate(iso: string): string {
+    const date = new Date(iso)
+    const now = new Date()
+    const diff = now.getTime() - date.getTime()
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+    if (days === 0) return 'Today'
+    if (days === 1) return 'Yesterday'
+    if (days < 7) return `${days} days ago`
+    return date.toLocaleDateString()
   }
 </script>
 
@@ -44,7 +73,7 @@
 {/if}
 
 <div class="welcome">
-  <div class="welcome-content">
+  <div class="welcome-left">
     <h1 class="welcome-title">Quilltorium</h1>
     <p class="welcome-subtitle">Your novel. Your files. Your way.</p>
 
@@ -62,6 +91,27 @@
       <p>No accounts. No cloud. No lock-in.</p>
     </div>
   </div>
+
+  {#if recentProjects.length > 0}
+    <div class="welcome-right">
+      <h2 class="recent-title">Recent Projects</h2>
+      <div class="recent-list">
+        {#each recentProjects as project}
+          <button
+            class="recent-item"
+            on:click={() => handleOpenRecent(project.path)}
+          >
+            <span class="recent-icon">📖</span>
+            <div class="recent-info">
+              <span class="recent-name">{project.title}</span>
+              <span class="recent-path">{project.path}</span>
+              <span class="recent-date">{formatDate(project.lastOpened)}</span>
+            </div>
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -70,17 +120,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 80px;
     background: var(--color-bg);
+    padding: var(--space-xl);
   }
 
-  .welcome-content {
+  .welcome-left {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     gap: 16px;
-    max-width: 400px;
-    text-align: center;
-    padding: 48px;
+    max-width: 320px;
   }
 
   .welcome-title {
@@ -104,7 +154,7 @@
   .welcome-actions {
     display: flex;
     gap: 12px;
-    margin-top: 16px;
+    margin-top: 8px;
   }
 
   .btn-primary {
@@ -120,9 +170,7 @@
     transition: opacity 0.15s;
   }
 
-  .btn-primary:hover {
-    opacity: 0.85;
-  }
+  .btn-primary:hover { opacity: 0.85; }
 
   .btn-secondary {
     padding: 10px 24px;
@@ -136,12 +184,9 @@
     transition: background 0.15s;
   }
 
-  .btn-secondary:hover {
-    background: var(--color-surface-hover);
-  }
+  .btn-secondary:hover { background: var(--color-surface-hover); }
 
   .welcome-hint {
-    margin-top: 24px;
     padding: 16px;
     background: var(--color-surface);
     border-radius: 8px;
@@ -156,7 +201,77 @@
     line-height: 1.5;
   }
 
-  .welcome-hint p:last-child {
+  .welcome-hint p:last-child { margin: 0; }
+
+  .welcome-right {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 300px;
+  }
+
+  .recent-title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
     margin: 0;
+  }
+
+  .recent-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .recent-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s;
+    width: 100%;
+  }
+
+  .recent-item:hover { border-color: var(--color-accent); }
+
+  .recent-icon { font-size: 18px; flex-shrink: 0; }
+
+  .recent-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .recent-name {
+    font-family: var(--font-display);
+    font-size: 15px;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .recent-path {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-text-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .recent-date {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--color-text-muted);
   }
 </style>


### PR DESCRIPTION
Closes #47 — Adds recent projects panel to welcome screen showing last 10 opened projects with title, path, and relative date. Click to open directly. Missing projects are removed from the list automatically.