### PR TITLE
feat: add project settings panel and wire word count goal to stats

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1139,6 +1139,37 @@ ipcMain.handle('app:open-recent-project', async (
   }
 })
 
+/** Get the current project's metadata */
+ipcMain.handle('project:get-metadata', async (): Promise<ProjectMetadata | null> => {
+  if (!currentProjectPath) return null
+  try {
+    const raw = await adapter.readFile(join(currentProjectPath, 'project.json'))
+    return JSON.parse(raw) as ProjectMetadata
+  } catch (error) {
+    console.error('Failed to get project metadata:', error)
+    return null
+  }
+})
+
+/** Update the current project's settings */
+ipcMain.handle('project:update-settings', async (
+  _event,
+  updates: Partial<ProjectMetadata>
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+  try {
+    const projectJsonPath = join(currentProjectPath, 'project.json')
+    const raw = await adapter.readFile(projectJsonPath)
+    const metadata: ProjectMetadata = JSON.parse(raw)
+    const updated = { ...metadata, ...updates }
+    await adapter.writeFile(projectJsonPath, JSON.stringify(updated, null, 2))
+    return true
+  } catch (error) {
+    console.error('Failed to update project settings:', error)
+    return false
+  }
+})
+
 // Windows: quit the app when all windows are closed
 app.on('window-all-closed', () => {
   app.quit()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,12 @@ const api = {
 
   openRecentProject: (projectPath: string): Promise<ProjectMetadata | null> =>
     ipcRenderer.invoke('app:open-recent-project', projectPath),
+
+  getProjectMetadata: (): Promise<ProjectMetadata | null> =>
+    ipcRenderer.invoke('project:get-metadata'),
+
+  updateProjectSettings: (updates: Partial<ProjectMetadata>): Promise<boolean> =>
+    ipcRenderer.invoke('project:update-settings', updates),
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -16,6 +16,7 @@
   import { resetLocations } from './stores/locations'
   import LocationMetadataPanel from './components/LocationMetadataPanel.svelte'
   import PlotBoardView from './views/PlotBoardView.svelte'
+  import ProjectSettingsView from './views/ProjectSettingsView.svelte'
 
   function handleCloseProject(): void {
     resetScenes()
@@ -97,6 +98,8 @@
             <SceneMetadataPanel sceneId={$appState.activeSceneId} />
           {:else}
             <div class="editor-placeholder">Select a scene to start writing</div>
+          {:else if $appState.activeSection === 'settings'}
+            <ProjectSettingsView />  
           {/if}
         </div>
       </div>

--- a/src/renderer/src/components/NavRail.svelte
+++ b/src/renderer/src/components/NavRail.svelte
@@ -39,7 +39,13 @@
   </div>
 
   <div class="nav-footer">
-    <button class="nav-item" title="Settings">
+    <button
+      class="nav-item"
+      class:active={$appState.activeSection === 'settings'}
+      disabled={$appState.projectPath === null}
+      on:click={() => setActiveSection('settings')}
+      title="Settings"
+    >
       <span class="nav-icon">⚙</span>
       <span class="nav-label">Settings</span>
     </button>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -39,6 +39,8 @@ declare global {
       ): Promise<boolean>
       getRecentProjects(): Promise<Array<{ path: string; title: string; lastOpened: string }>>
       openRecentProject(projectPath: string): Promise<ProjectMetadata | null>
+      getProjectMetadata(): Promise<ProjectMetadata | null>
+      updateProjectSettings(updates: Partial<ProjectMetadata>): Promise<boolean>
     }
   }
 }

--- a/src/renderer/src/stores/app.ts
+++ b/src/renderer/src/stores/app.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store'
+import type { ProjectMetadata } from '../env'
 
-export type AppSection = 'scenes' | 'characters' | 'locations' | 'lore' | 'notes' | 'plot' | 'stats'
+export type AppSection = 'scenes' | 'characters' | 'locations' | 'lore' | 'notes' | 'plot' | 'stats' | 'settings'
 
 interface AppState {
   activeSection: AppSection
@@ -9,6 +10,7 @@ interface AppState {
   activeSceneId: string | null
   activeCharacterId: string | null
   activeLocationId: string | null
+  projectMetadata: ProjectMetadata | null
 }
 
 const initialState: AppState = {
@@ -17,7 +19,8 @@ const initialState: AppState = {
   projectTitle: null,
   activeSceneId: null,
   activeCharacterId: null,
-  activeLocationId: null
+  activeLocationId: null,
+  projectMetadata: null
 }
 
 export const appState = writable<AppState>(initialState)
@@ -28,6 +31,10 @@ export function setActiveSection(section: AppSection): void {
 
 export function setProject(id: string, title: string): void {
   appState.update(state => ({ ...state, projectPath: id, projectTitle: title }))
+}
+
+export function setProjectMetadata(metadata: ProjectMetadata): void {
+  appState.update(state => ({ ...state, projectMetadata: metadata }))
 }
 
 export function setActiveScene(id: string): void {
@@ -41,6 +48,7 @@ export function closeProject(): void {
     projectTitle: null,
     activeSceneId: null,
     activeCharacterId: null,
-    activeLocationId: null
+    activeLocationId: null,
+    projectMetadata: null
   }))
 }

--- a/src/renderer/src/views/ProjectSettingsView.svelte
+++ b/src/renderer/src/views/ProjectSettingsView.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import { appState, setProjectMetadata } from '../stores/app'
+
+  $: metadata = $appState.projectMetadata
+
+  let saving = false
+  let saved = false
+
+  // Local form state
+  let title = ''
+  let author = ''
+  let targetWordCount: string | number = ''
+
+  // Sync form state when metadata loads
+  $: if (metadata) {
+    title = metadata.title
+    author = metadata.author
+    targetWordCount = metadata.settings.targetWordCount?.toString() ?? ''
+  }
+
+  async function handleSave(): Promise<void> {
+    if (!metadata) return
+    saving = true
+
+    const wordCountNum = targetWordCount === '' || targetWordCount === null || targetWordCount === undefined
+        ? null
+        : parseInt(String(targetWordCount))
+
+    const updates = {
+      title: title.trim() || metadata.title,
+      author: author.trim(),
+      settings: {
+        ...metadata.settings,
+        targetWordCount: isNaN(wordCountNum ?? NaN) ? null : wordCountNum
+      }
+    }
+
+    const success = await window.api.updateProjectSettings(updates)
+    if (success) {
+      const updated = await window.api.getProjectMetadata()
+      if (updated) {
+        setProjectMetadata(updated)
+        // Update the titlebar
+        appState.update(s => ({ ...s, projectTitle: updated.title }))
+      }
+      saved = true
+      setTimeout(() => { saved = false }, 2000)
+    }
+
+    saving = false
+  }
+</script>
+
+{#if metadata}
+  <div class="settings-view">
+    <div class="settings-header">
+      <h2 class="settings-title">Project Settings</h2>
+      <p class="settings-subtitle">{metadata.title}</p>
+    </div>
+
+    <div class="settings-body">
+
+      <div class="settings-card">
+        <h3 class="card-title">Project Info</h3>
+
+        <div class="field">
+          <label for="proj-title">Novel Title</label>
+          <input
+            id="proj-title"
+            type="text"
+            bind:value={title}
+          />
+        </div>
+
+        <div class="field">
+          <label for="proj-author">Author Name</label>
+          <input
+            id="proj-author"
+            type="text"
+            placeholder="Your name"
+            bind:value={author}
+          />
+        </div>
+      </div>
+
+      <div class="settings-card">
+        <h3 class="card-title">Writing Goals</h3>
+
+        <div class="field">
+          <label for="word-goal">Target Word Count</label>
+          <input
+            id="word-goal"
+            type="number"
+            placeholder="e.g. 80000"
+            bind:value={targetWordCount}
+            min="0"
+          />
+          <p class="field-hint">Used for progress tracking in the Stats panel. Leave blank for no goal.</p>
+        </div>
+      </div>
+
+      <div class="settings-card">
+        <h3 class="card-title">Project Info</h3>
+        <div class="info-grid">
+          <span class="info-label">Created</span>
+          <span class="info-value">{new Date(metadata.created).toLocaleDateString()}</span>
+          <span class="info-label">Last Opened</span>
+          <span class="info-value">{new Date(metadata.lastOpened).toLocaleDateString()}</span>
+          <span class="info-label">Format Version</span>
+          <span class="info-value">{metadata.formatVersion}</span>
+          <span class="info-label">Project ID</span>
+          <span class="info-value info-id">{metadata.id}</span>
+        </div>
+      </div>
+
+      <div class="settings-actions">
+        <button
+          class="btn-save"
+          on:click={handleSave}
+          disabled={saving}
+        >
+          {saving ? 'Saving...' : saved ? '✓ Saved' : 'Save Settings'}
+        </button>
+      </div>
+
+    </div>
+  </div>
+{:else}
+  <div class="settings-empty">
+    <p>No project open.</p>
+  </div>
+{/if}
+
+<style>
+  .settings-view {
+    flex: 1;
+    overflow-y: auto;
+    background: var(--color-bg);
+  }
+
+  .settings-header {
+    padding: var(--space-xl) var(--space-xl) var(--space-lg);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .settings-title {
+    font-family: var(--font-display);
+    font-size: 28px;
+    font-weight: 400;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+
+  .settings-subtitle {
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  .settings-body {
+    padding: var(--space-lg) var(--space-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    max-width: 500px;
+  }
+
+  .settings-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: var(--space-md) var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .card-title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  label {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  input {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 8px 10px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+  }
+
+  input:focus { border-color: var(--color-accent); }
+
+  .field-hint {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--color-text-faint);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .info-grid {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 6px 12px;
+    align-items: baseline;
+  }
+
+  .info-label {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .info-value {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-text);
+  }
+
+  .info-id {
+    font-size: 10px;
+    color: var(--color-text-faint);
+    word-break: break-all;
+  }
+
+  .settings-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .btn-save {
+    padding: 10px 24px;
+    background: var(--color-accent);
+    color: #1a1a1f;
+    border: none;
+    border-radius: 6px;
+    font-family: var(--font-ui);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-save:hover:not(:disabled) { opacity: 0.85; }
+  .btn-save:disabled { opacity: 0.6; cursor: not-allowed; }
+
+  .settings-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-faint);
+    font-family: var(--font-ui);
+    font-size: 13px;
+  }
+</style>

--- a/src/renderer/src/views/StatsView.svelte
+++ b/src/renderer/src/views/StatsView.svelte
@@ -16,8 +16,8 @@
     .filter(s => s.status === 'final')
     .reduce((sum, s) => sum + s.wordCount, 0)
 
-  /** Target word count from project settings — hardcoded default for now */
-  const TARGET_WORD_COUNT = 80000
+  /** Target word count from project settings */
+  $: TARGET_WORD_COUNT = $appState.projectMetadata?.settings.targetWordCount ?? 80000
 
   /** Progress percentage toward target */
   $: progressPercent = Math.min((totalWords / TARGET_WORD_COUNT) * 100, 100)
@@ -53,7 +53,7 @@
       </div>
       <div class="progress-meta">
         <span>{progressPercent.toFixed(1)}% of {fmt(TARGET_WORD_COUNT)} word goal</span>
-        <span>{fmt(TARGET_WORD_COUNT - totalWords)} words remaining</span>
+        <span>{TARGET_WORD_COUNT > totalWords ? `${fmt(TARGET_WORD_COUNT - totalWords)} words remaining` : '🎉 Goal reached!'}</span>
       </div>
     </div>
 

--- a/src/renderer/src/views/WelcomeView.svelte
+++ b/src/renderer/src/views/WelcomeView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { setProject } from '../stores/app'
+  import { setProject, setProjectMetadata } from '../stores/app'
   import { loadScenes } from '../stores/scenes'
   import { loadCharacters } from '../stores/characters'
   import { loadLocations } from '../stores/locations'
@@ -16,6 +16,7 @@
   async function openProject(metadata: Awaited<ReturnType<typeof window.api.openProject>>): Promise<void> {
     if (metadata) {
       setProject(metadata.id, metadata.title)
+      setProjectMetadata(metadata)
       await Promise.all([loadScenes(), loadCharacters(), loadLocations()])
       recentProjects = await window.api.getRecentProjects()
     }


### PR DESCRIPTION
Closes #48, Closes #49 — Adds project settings panel accessible from nav rail footer showing title, author, and word count goal. Settings persist to project.json. Stats panel now reads word count goal from project settings instead of hardcoded value. Title bar updates immediately on save.