### PR TITLE
feat: add export filters modal with status selection and title toggle

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -484,151 +484,142 @@ ipcMain.handle('scenes:update-metadata', async (
   }
 })
 
-/** Export all scenes as a compiled manuscript .docx file */
-ipcMain.handle('manuscript:export', async (): Promise<boolean> => {
-  if (!currentProjectPath) return false
+  /** Export all scenes as a compiled manuscript .docx file */
+  ipcMain.handle('manuscript:export', async (
+    _event,
+    options: { includeStatuses: string[]; includeTitles: boolean }
+  ): Promise<boolean> => {
+    if (!currentProjectPath) return false
 
-  try {
-    // Get all scenes sorted by order
-    const scenesDir = join(currentProjectPath, 'scenes')
-    const files = await adapter.listFiles(scenesDir)
-    const jsonFiles = files.filter(f => f.endsWith('.json'))
+    try {
+      const scenesDir = join(currentProjectPath, 'scenes')
+      const files = await adapter.listFiles(scenesDir)
+      const jsonFiles = files.filter(f => f.endsWith('.json'))
 
-    const scenes: Array<{ metadata: SceneMetadata; content: string }> = []
+      const scenes: Array<{ metadata: SceneMetadata; content: string }> = []
 
-    for (const file of jsonFiles) {
-      try {
-        const raw = await adapter.readFile(file)
-        const metadata = JSON.parse(raw) as SceneMetadata
-        const mdPath = file.replace('.json', '.md')
-        const content = await adapter.readFile(mdPath)
-        scenes.push({ metadata, content })
-      } catch {
-        // Skip malformed files
+      for (const file of jsonFiles) {
+        try {
+          const raw = await adapter.readFile(file)
+          const metadata = JSON.parse(raw) as SceneMetadata
+          // Filter by status
+          if (!options.includeStatuses.includes(metadata.status)) continue
+          const mdPath = file.replace('.json', '.md')
+          const content = await adapter.readFile(mdPath)
+          scenes.push({ metadata, content })
+        } catch {
+          // Skip malformed files
+        }
       }
-    }
 
-    scenes.sort((a, b) => a.metadata.order - b.metadata.order)
+      scenes.sort((a, b) => a.metadata.order - b.metadata.order)
 
-    if (scenes.length === 0) {
+      if (scenes.length === 0) {
+        await dialog.showMessageBox({
+          type: 'info',
+          title: 'No Scenes to Export',
+          message: 'No scenes match the selected filters.',
+          detail: 'Try including more status types in the export options.'
+        })
+        return false
+      }
+
+      const result = await dialog.showSaveDialog({
+        title: 'Export Manuscript',
+        defaultPath: 'manuscript.docx',
+        filters: [{ name: 'Word Document', extensions: ['docx'] }]
+      })
+
+      if (result.canceled || !result.filePath) return false
+
+      const children: Paragraph[] = []
+
+      for (const { metadata, content } of scenes) {
+        if (options.includeTitles) {
+          children.push(
+            new Paragraph({
+              text: metadata.title,
+              heading: HeadingLevel.HEADING_1,
+              spacing: { before: 480, after: 240 }
+            })
+          )
+        }
+
+        const paragraphs = content.split(/\n\n+/).filter(p => p.trim() !== '')
+
+        for (const para of paragraphs) {
+          const text = para
+            .replace(/^#{1,6}\s+/, '')
+            .replace(/\*\*(.*?)\*\*/g, '$1')
+            .replace(/\*(.*?)\*/g, '$1')
+            .replace(/\n/g, ' ')
+            .trim()
+
+          if (text === '') continue
+
+          children.push(
+            new Paragraph({
+              children: [new TextRun({ text, size: 24 })],
+              spacing: { before: 0, after: 240 },
+              alignment: AlignmentType.LEFT,
+              indent: { firstLine: 720 }
+            })
+          )
+        }
+      }
+
+      const projectRaw = await adapter.readFile(join(currentProjectPath, 'project.json'))
+      const project = JSON.parse(projectRaw)
+
+      const doc = new Document({
+        sections: [{
+          properties: {
+            page: {
+              size: { width: 12240, height: 15840 },
+              margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 }
+            }
+          },
+          children: [
+            new Paragraph({
+              children: [new TextRun({ text: project.title, size: 48, bold: true })],
+              alignment: AlignmentType.CENTER,
+              spacing: { before: 2880, after: 480 }
+            }),
+            new Paragraph({
+              children: [new TextRun({ text: project.author, size: 28 })],
+              alignment: AlignmentType.CENTER,
+              spacing: { before: 0, after: 0 }
+            }),
+            ...children
+          ]
+        }]
+      })
+
+      const buffer = await Packer.toBuffer(doc)
+      const { writeFileSync } = await import('fs')
+      writeFileSync(result.filePath, buffer)
+
       await dialog.showMessageBox({
         type: 'info',
-        title: 'No Scenes',
-        message: 'There are no scenes to export.'
+        title: 'Export Complete',
+        message: `Manuscript exported successfully.`,
+        detail: `${scenes.length} scenes saved to: ${result.filePath}`
+      })
+
+      return true
+    } catch (error) {
+      console.error('Failed to export manuscript:', error)
+      await dialog.showMessageBox({
+        type: 'error',
+        title: 'Export Failed',
+        message: 'Failed to export manuscript.',
+        detail: String(error)
       })
       return false
     }
+  })
 
-    // Ask where to save
-    const result = await dialog.showSaveDialog({
-      title: 'Export Manuscript',
-      defaultPath: `${scenes[0].metadata.title || 'manuscript'}.docx`,
-      filters: [{ name: 'Word Document', extensions: ['docx'] }]
-    })
 
-    if (result.canceled || !result.filePath) return false
-
-    // Build document paragraphs
-    const children: Paragraph[] = []
-
-    for (const { metadata, content } of scenes) {
-      // Scene title as heading
-      children.push(
-        new Paragraph({
-          text: metadata.title,
-          heading: HeadingLevel.HEADING_1,
-          spacing: { before: 480, after: 240 }
-        })
-      )
-
-      // Scene content — split into paragraphs by blank lines
-      const paragraphs = content.split(/\n\n+/).filter(p => p.trim() !== '')
-
-      for (const para of paragraphs) {
-        const text = para
-          .replace(/^#{1,6}\s+/, '') // Strip markdown headings
-          .replace(/\*\*(.*?)\*\*/g, '$1') // Strip bold
-          .replace(/\*(.*?)\*/g, '$1') // Strip italic
-          .replace(/\n/g, ' ') // Join lines
-          .trim()
-
-        if (text === '') continue
-
-        children.push(
-          new Paragraph({
-            children: [new TextRun({ text, size: 24 })],
-            spacing: { before: 0, after: 240 },
-            alignment: AlignmentType.LEFT,
-            indent: { firstLine: 720 }
-          })
-        )
-      }
-    }
-
-    // Read project metadata for title page
-    const projectRaw = await adapter.readFile(join(currentProjectPath, 'project.json'))
-    const project = JSON.parse(projectRaw)
-
-    const doc = new Document({
-      sections: [{
-        properties: {
-          page: {
-            size: {
-              width: 12240,
-              height: 15840
-            },
-            margin: {
-              top: 1440,
-              right: 1440,
-              bottom: 1440,
-              left: 1440
-            }
-          }
-        },
-        children: [
-          // Title page
-          new Paragraph({
-            children: [new TextRun({ text: project.title, size: 48, bold: true })],
-            alignment: AlignmentType.CENTER,
-            spacing: { before: 2880, after: 480 }
-          }),
-          new Paragraph({
-            children: [new TextRun({ text: project.author, size: 28 })],
-            alignment: AlignmentType.CENTER,
-            spacing: { before: 0, after: 0 }
-          }),
-          // Scene content
-          ...children
-        ]
-      }]
-    })
-
-    const buffer = await Packer.toBuffer(doc)
-    await adapter.writeFile(result.filePath, buffer.toString('binary'))
-
-    // Verify the file was written correctly using binary write
-    const { writeFileSync } = await import('fs')
-    writeFileSync(result.filePath, buffer)
-
-    await dialog.showMessageBox({
-      type: 'info',
-      title: 'Export Complete',
-      message: `Manuscript exported successfully.`,
-      detail: `Saved to: ${result.filePath}`
-    })
-
-    return true
-  } catch (error) {
-    console.error('Failed to export manuscript:', error)
-    await dialog.showMessageBox({
-      type: 'error',
-      title: 'Export Failed',
-      message: 'Failed to export manuscript.',
-      detail: String(error)
-    })
-    return false
-  }
-})
 
 // ── Character Handlers ───────────────────────────────────────────────────────
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,11 +33,14 @@ const api = {
   ): Promise<boolean> =>
     ipcRenderer.invoke('scenes:update-metadata', sceneId, updates),
 
-  exportManuscript: (): Promise<boolean> =>
-    ipcRenderer.invoke('manuscript:export'),
+  exportManuscript: (options: {
+    includeStatuses: string[]
+    includeTitles: boolean
+  }): Promise<boolean> =>
+    ipcRenderer.invoke('manuscript:export', options),
 
   listCharacters: (): Promise<CharacterMetadata[]> =>
-  ipcRenderer.invoke('characters:list'),
+    ipcRenderer.invoke('characters:list'),
 
   createCharacter: (name: string): Promise<CharacterMetadata | null> =>
     ipcRenderer.invoke('characters:create', name),

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -17,6 +17,7 @@
   import LocationMetadataPanel from './components/LocationMetadataPanel.svelte'
   import PlotBoardView from './views/PlotBoardView.svelte'
   import ProjectSettingsView from './views/ProjectSettingsView.svelte'
+  import ExportModal from './components/ExportModal.svelte'
 
   function handleCloseProject(): void {
     resetScenes()
@@ -25,11 +26,30 @@
     closeProject()
   }
 
-  async function handleExport(): Promise<void> {
-    await window.api.exportManuscript()
+  let showExportModal = false
+
+  function handleExport(): void {
+    showExportModal = true
+  }
+
+  async function handleExportConfirm(
+    e: CustomEvent<{ includeStatuses: string[]; includeTitles: boolean }>
+  ): Promise<void> {
+    showExportModal = false
+    await window.api.exportManuscript(e.detail)
+  }
+
+  function handleExportCancel(): void {
+    showExportModal = false
   }
 </script>
 
+{#if showExportModal}
+  <ExportModal
+    on:confirm={handleExportConfirm}
+    on:cancel={handleExportCancel}
+  />
+{/if}
 <div class="app-shell">
   <!-- Title bar -->
   <div class="title-bar">

--- a/src/renderer/src/components/ExportModal.svelte
+++ b/src/renderer/src/components/ExportModal.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+  import { scenesState } from '../stores/scenes'
+
+  const dispatch = createEventDispatcher<{
+    confirm: { includeStatuses: string[]; includeTitles: boolean }
+    cancel: void
+  }>()
+
+  let includeDraft = false
+  let includeRevise = true
+  let includeFinal = true
+  let includeTitles = true
+
+  $: sceneCount = $scenesState.scenes.filter(s => {
+    if (s.status === 'draft' && !includeDraft) return false
+    if (s.status === 'revise' && !includeRevise) return false
+    if (s.status === 'final' && !includeFinal) return false
+    return true
+  }).length
+
+  function handleConfirm(): void {
+    const includeStatuses: string[] = []
+    if (includeDraft) includeStatuses.push('draft')
+    if (includeRevise) includeStatuses.push('revise')
+    if (includeFinal) includeStatuses.push('final')
+    dispatch('confirm', { includeStatuses, includeTitles })
+  }
+
+  function handleCancel(): void {
+    dispatch('cancel')
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') handleCancel()
+  }
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<div class="modal-backdrop" on:click={handleCancel}>
+  <div class="modal" on:click|stopPropagation>
+    <h2 class="modal-title">Export Manuscript</h2>
+
+    <div class="section">
+      <label class="section-label">Include Scenes</label>
+      <div class="checkbox-group">
+        <label class="checkbox-row">
+          <input type="checkbox" bind:checked={includeFinal} />
+          <span class="status-dot final"></span>
+          <span>Final</span>
+        </label>
+        <label class="checkbox-row">
+          <input type="checkbox" bind:checked={includeRevise} />
+          <span class="status-dot revise"></span>
+          <span>Revise</span>
+        </label>
+        <label class="checkbox-row">
+          <input type="checkbox" bind:checked={includeDraft} />
+          <span class="status-dot draft"></span>
+          <span>Draft</span>
+        </label>
+      </div>
+    </div>
+
+    <div class="section">
+      <label class="section-label">Formatting</label>
+      <div class="checkbox-group">
+        <label class="checkbox-row">
+          <input type="checkbox" bind:checked={includeTitles} />
+          <span>Include scene titles as headings</span>
+        </label>
+      </div>
+    </div>
+
+    <div class="export-summary">
+      <span class="summary-icon">📄</span>
+      <span class="summary-text">
+        {sceneCount} scene{sceneCount !== 1 ? 's' : ''} will be exported
+      </span>
+    </div>
+
+    <div class="modal-actions">
+      <button class="btn-secondary" on:click={handleCancel}>Cancel</button>
+      <button
+        class="btn-primary"
+        on:click={handleConfirm}
+        disabled={sceneCount === 0}
+      >
+        Export to .docx
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    padding: 28px;
+    width: 380px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .modal-title {
+    font-family: var(--font-display);
+    font-size: 24px;
+    font-weight: 400;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .section-label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 10px 12px;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .checkbox-row input[type="checkbox"] {
+    accent-color: var(--color-accent);
+    cursor: pointer;
+  }
+
+  .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot.draft  { background: var(--color-draft); }
+  .status-dot.revise { background: var(--color-revise); }
+  .status-dot.final  { background: var(--color-final); }
+
+  .export-summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--color-accent-subtle);
+    border: 1px solid var(--color-accent);
+    border-radius: 6px;
+  }
+
+  .summary-icon { font-size: 16px; }
+
+  .summary-text {
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-accent);
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+
+  .btn-primary {
+    padding: 9px 20px;
+    background: var(--color-accent);
+    color: #1a1a1f;
+    border: none;
+    border-radius: 6px;
+    font-family: var(--font-ui);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .btn-primary:hover:not(:disabled) { opacity: 0.85; }
+  .btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .btn-secondary {
+    padding: 9px 20px;
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-family: var(--font-ui);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .btn-secondary:hover { background: var(--color-surface-hover); }
+</style>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -18,7 +18,10 @@ declare global {
         sceneId: string,
         updates: Partial<SceneMetadata>
       ): Promise<boolean>
-      exportManuscript(): Promise<boolean>
+      exportManuscript(options: {
+        includeStatuses: string[]
+        includeTitles: boolean
+      }): Promise<boolean>
       listCharacters(): Promise<CharacterMetadata[]>
       createCharacter(name: string): Promise<CharacterMetadata | null>
       readCharacter(characterId: string): Promise<string>


### PR DESCRIPTION
Closes #50 — Adds export options modal before manuscript export allowing selection of which scene statuses to include and whether to include scene titles as headings. Shows live count of scenes that will be exported.