### PR TITLE
feat: add lore wiki with wikilink highlighting, backlinks, and cross-…

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { autoUpdater } from 'electron-updater'
 import icon from '../../resources/icon.png?asset'
 import { ElectronAdapter } from '../../src-shared/storage/ElectronAdapter'
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
 import { Document, Packer, Paragraph, TextRun, HeadingLevel, AlignmentType } from 'docx'
 
 
@@ -1158,6 +1158,248 @@ ipcMain.handle('project:update-settings', async (
   } catch (error) {
     console.error('Failed to update project settings:', error)
     return false
+  }
+})
+
+// ── Lore Handlers ────────────────────────────────────────────────────────────
+
+/** List all lore pages for the current project, sorted alphabetically */
+ipcMain.handle('lore:list', async (): Promise<LoreMetadata[]> => {
+  if (!currentProjectPath) return []
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    const pages: LoreMetadata[] = []
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        pages.push(JSON.parse(raw) as LoreMetadata)
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    return pages.sort((a, b) => a.title.localeCompare(b.title))
+  } catch (error) {
+    console.error('Failed to list lore pages:', error)
+    return []
+  }
+})
+
+/** Create a new lore page */
+ipcMain.handle('lore:create', async (
+  _event,
+  title: string
+): Promise<LoreMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+
+    const baseSlug = slugify(title)
+    let slug = baseSlug
+    let counter = 1
+
+    while (await adapter.exists(join(loreDir, `${slug}.json`))) {
+      slug = `${baseSlug}-${counter}`
+      counter++
+    }
+
+    const now = new Date().toISOString()
+    const metadata: LoreMetadata = {
+      id: crypto.randomUUID(),
+      slug,
+      title,
+      tags: [],
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(loreDir, `${slug}.md`), `# ${title}\n\n`)
+    await adapter.writeFile(
+      join(loreDir, `${slug}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to create lore page:', error)
+    return null
+  }
+})
+
+/** Read a lore page's Markdown content */
+ipcMain.handle('lore:read', async (
+  _event,
+  loreId: string
+): Promise<string> => {
+  if (!currentProjectPath) return ''
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        const metadata = JSON.parse(raw) as LoreMetadata
+        if (metadata.id === loreId) {
+          return await adapter.readFile(file.replace('.json', '.md'))
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+    return ''
+  } catch (error) {
+    console.error('Failed to read lore page:', error)
+    return ''
+  }
+})
+
+/** Save a lore page's Markdown content */
+ipcMain.handle('lore:save', async (
+  _event,
+  loreId: string,
+  content: string
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        const metadata = JSON.parse(raw) as LoreMetadata
+        if (metadata.id === loreId) {
+          await adapter.writeFile(file.replace('.json', '.md'), content)
+          metadata.updatedAt = new Date().toISOString()
+          await adapter.writeFile(file, JSON.stringify(metadata, null, 2))
+          return true
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+    return false
+  } catch (error) {
+    console.error('Failed to save lore page:', error)
+    return false
+  }
+})
+
+/** Delete a lore page */
+ipcMain.handle('lore:delete', async (
+  _event,
+  loreId: string
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        const metadata = JSON.parse(raw) as LoreMetadata
+        if (metadata.id === loreId) {
+          await adapter.deleteFile(file)
+          await adapter.deleteFile(file.replace('.json', '.md'))
+          return true
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+    return false
+  } catch (error) {
+    console.error('Failed to delete lore page:', error)
+    return false
+  }
+})
+
+/** Update a lore page's metadata */
+ipcMain.handle('lore:update-metadata', async (
+  _event,
+  loreId: string,
+  updates: Partial<LoreMetadata>
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        const metadata = JSON.parse(raw) as LoreMetadata
+        if (metadata.id === loreId) {
+          const updated = {
+            ...metadata,
+            ...updates,
+            id: metadata.id,
+            slug: metadata.slug,
+            createdAt: metadata.createdAt,
+            updatedAt: new Date().toISOString()
+          }
+          await adapter.writeFile(file, JSON.stringify(updated, null, 2))
+          return true
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+    return false
+  } catch (error) {
+    console.error('Failed to update lore metadata:', error)
+    return false
+  }
+})
+
+/** Get backlinks — find all lore pages that link to a given slug */
+ipcMain.handle('lore:get-backlinks', async (
+  _event,
+  targetSlug: string
+): Promise<LoreMetadata[]> => {
+  if (!currentProjectPath) return []
+
+  try {
+    const loreDir = join(currentProjectPath, 'lore')
+    const files = await adapter.listFiles(loreDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    const backlinks: LoreMetadata[] = []
+    const wikilinkPattern = new RegExp(`\\[\\[${targetSlug}\\]\\]`, 'i')
+
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        const metadata = JSON.parse(raw) as LoreMetadata
+        if (metadata.slug === targetSlug) continue
+        const mdContent = await adapter.readFile(file.replace('.json', '.md'))
+        if (wikilinkPattern.test(mdContent)) {
+          backlinks.push(metadata)
+        }
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    return backlinks.sort((a, b) => a.title.localeCompare(b.title))
+  } catch (error) {
+    console.error('Failed to get backlinks:', error)
+    return []
   }
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
 
 const api = {
   openProject: (): Promise<ProjectMetadata | null> =>
@@ -92,6 +92,29 @@ const api = {
 
   updateProjectSettings: (updates: Partial<ProjectMetadata>): Promise<boolean> =>
     ipcRenderer.invoke('project:update-settings', updates),
+  listLore: (): Promise<LoreMetadata[]> =>
+    ipcRenderer.invoke('lore:list'),
+
+  createLore: (title: string): Promise<LoreMetadata | null> =>
+    ipcRenderer.invoke('lore:create', title),
+
+  readLore: (loreId: string): Promise<string> =>
+    ipcRenderer.invoke('lore:read', loreId),
+
+  saveLore: (loreId: string, content: string): Promise<boolean> =>
+    ipcRenderer.invoke('lore:save', loreId, content),
+
+  deleteLore: (loreId: string): Promise<boolean> =>
+    ipcRenderer.invoke('lore:delete', loreId),
+
+  updateLoreMetadata: (
+    loreId: string,
+    updates: Partial<LoreMetadata>
+  ): Promise<boolean> =>
+    ipcRenderer.invoke('lore:update-metadata', loreId, updates),
+
+  getLoreBacklinks: (targetSlug: string): Promise<LoreMetadata[]> =>
+    ipcRenderer.invoke('lore:get-backlinks', targetSlug),
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -19,11 +19,16 @@
   import ProjectSettingsView from './views/ProjectSettingsView.svelte'
   import ExportModal from './components/ExportModal.svelte'
   import TimelineView from './views/TimelineView.svelte'
+  import LoreListSidebar from './components/LoreListSidebar.svelte'
+  import LoreEditor from './components/LoreEditor.svelte'
+  import LoreMetadataPanel from './components/LoreMetadataPanel.svelte'
+  import { resetLore } from './stores/lore'
 
   function handleCloseProject(): void {
     resetScenes()
     resetCharacters()
     resetLocations()
+    resetLore()
     closeProject()
   }
 
@@ -86,7 +91,9 @@
         {:else if $appState.activeSection === 'characters'}
           <CharacterListSidebar />
         {:else if $appState.activeSection === 'locations'}
-          <LocationListSidebar />  
+          <LocationListSidebar />
+        {:else if $appState.activeSection === 'lore'}
+          <LoreListSidebar />  
         {/if}
 
         <div class="main-editor">
@@ -114,6 +121,15 @@
             {:else}
               <div class="editor-placeholder">Select a location to view its page</div>
               {/if}
+          {:else if $appState.activeSection === 'lore'}
+            {#if $appState.activeLoreId}
+              {#key $appState.activeLoreId}
+                <LoreEditor loreId={$appState.activeLoreId} />
+              {/key}
+              <LoreMetadataPanel loreId={$appState.activeLoreId} />
+            {:else}
+              <div class="editor-placeholder">Select a lore page to start writing</div>
+            {/if}  
           {:else if $appState.activeSceneId}
             {#key $appState.activeSceneId}
               <SceneEditor sceneId={$appState.activeSceneId} />

--- a/src/renderer/src/components/LoreEditor.svelte
+++ b/src/renderer/src/components/LoreEditor.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  import { appState } from '../stores/app'
+  import { onMount, onDestroy } from 'svelte'
+  import { EditorState, RangeSetBuilder } from '@codemirror/state'
+  import { EditorView, keymap, drawSelection, Decoration } from '@codemirror/view'
+  import { defaultKeymap, historyKeymap, history } from '@codemirror/commands'
+  import { markdown } from '@codemirror/lang-markdown'
+  import { languages } from '@codemirror/language-data'
+  import { ViewPlugin, type ViewUpdate } from '@codemirror/view'
+  import { loreState } from '../stores/lore'
+  import { charactersState } from '../stores/characters'
+  import { locationsState } from '../stores/locations'
+
+  export let loreId: string
+
+  let editorContainer: HTMLDivElement
+  let editorView: EditorView | null = null
+  let saveTimeout: ReturnType<typeof setTimeout> | null = null
+  let isSaving = false
+  let isLoading = true
+
+  const AUTOSAVE_DELAY_MS = 2000
+
+  function scheduleSave(content: string): void {
+    if (saveTimeout) clearTimeout(saveTimeout)
+    saveTimeout = setTimeout(async () => {
+      isSaving = true
+      await window.api.saveLore(loreId, content)
+      isSaving = false
+    }, AUTOSAVE_DELAY_MS)
+  }
+
+  /** Highlight [[wikilinks]] in the editor */
+  const wikilinkMark = Decoration.mark({ class: 'cm-wikilink' })
+
+  const wikilinkPlugin = ViewPlugin.fromClass(
+    class {
+      decorations
+
+      constructor(view: EditorView) {
+        this.decorations = this.buildDecorations(view)
+      }
+
+      update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged) {
+          this.decorations = this.buildDecorations(update.view)
+        }
+      }
+
+      buildDecorations(view: EditorView) {
+        const builder = new RangeSetBuilder()
+        const pattern = /\[\[([^\]]+)\]\]/g
+        for (const { from, to } of view.visibleRanges) {
+          const text = view.state.doc.sliceString(from, to)
+          let match
+          while ((match = pattern.exec(text)) !== null) {
+            builder.add(from + match.index, from + match.index + match[0].length, wikilinkMark)
+          }
+        }
+        return builder.finish()
+      }
+    },
+    { decorations: v => v.decorations }
+  )
+
+  const quilltoriumTheme = EditorView.theme({
+    '&': {
+      height: '100%',
+      fontSize: '16px',
+      fontFamily: 'var(--font-display)',
+      backgroundColor: 'transparent',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
+      padding: '40px 0',
+      fontFamily: 'var(--font-display)',
+      lineHeight: '1.8',
+    },
+    '.cm-content': {
+      maxWidth: '680px',
+      margin: '0 auto',
+      padding: '0 24px',
+      caretColor: 'var(--color-accent)',
+      color: 'var(--color-text)',
+    },
+    '.cm-focused': { outline: 'none' },
+    '.cm-line': { padding: '0' },
+    '.cm-cursor': {
+      borderLeftColor: 'var(--color-accent)',
+      borderLeftWidth: '2px',
+    },
+    '.cm-selectionBackground': {
+      backgroundColor: 'var(--color-accent-subtle) !important',
+    },
+    '.cm-gutters': { display: 'none' },
+    '&.cm-focused .cm-selectionBackground': {
+      backgroundColor: 'var(--color-accent-subtle)',
+    },
+    '.cm-wikilink': {
+      color: 'var(--color-accent)',
+      backgroundColor: 'var(--color-accent-subtle)',
+      borderRadius: '3px',
+      padding: '0 2px',
+    },
+  }, { dark: true })
+
+  onMount(async () => {
+    const content = await window.api.readLore(loreId)
+    isLoading = false
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    if (!editorContainer) return
+
+    const state = EditorState.create({
+      doc: content,
+      extensions: [
+        history(),
+        drawSelection(),
+        markdown({ codeLanguages: languages }),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        quilltoriumTheme,
+        wikilinkPlugin,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            scheduleSave(update.state.doc.toString())
+          }
+        }),
+        EditorView.lineWrapping,
+
+        EditorView.domEventHandlers({
+            click(event, view) {
+                const pos = view.posAtCoords({ x: event.clientX, y: event.clientY })
+                if (pos === null) return false
+
+                const doc = view.state.doc.toString()
+                const before = doc.lastIndexOf('[[', pos)
+                const after = doc.indexOf(']]', pos)
+                if (before === -1 || after === -1 || before >= pos || after < pos) return false
+
+                const slug = doc.slice(before + 2, after).trim().toLowerCase()
+
+                // Check lore pages first
+                let foundLoreId: string | null = null
+                const unsubLore = loreState.subscribe(state => {
+                const found = state.pages.find(p => p.slug === slug)
+                if (found) foundLoreId = found.id
+                })
+                unsubLore()
+                if (foundLoreId) {
+                appState.update(s => ({ ...s, activeLoreId: foundLoreId }))
+                return true
+                }
+
+                // Check characters
+                let foundCharId: string | null = null
+                const unsubChar = charactersState.subscribe(state => {
+                const found = state.characters.find(c => c.slug === slug)
+                if (found) foundCharId = found.id
+                })
+                unsubChar()
+                if (foundCharId) {
+                appState.update(s => ({ ...s, activeSection: 'characters', activeCharacterId: foundCharId }))
+                return true
+                }
+
+                // Check locations
+                let foundLocId: string | null = null
+                const unsubLoc = locationsState.subscribe(state => {
+                const found = state.locations.find(l => l.slug === slug)
+                if (found) foundLocId = found.id
+                })
+                unsubLoc()
+                if (foundLocId) {
+                appState.update(s => ({ ...s, activeSection: 'locations', activeLocationId: foundLocId }))
+                return true
+                }
+
+                return false
+            }
+            }),
+      ]
+    })
+
+    editorView = new EditorView({ state, parent: editorContainer })
+    editorView.focus()
+  })
+
+  onDestroy(() => {
+    if (saveTimeout) clearTimeout(saveTimeout)
+    editorView?.destroy()
+  })
+</script>
+
+<div class="editor-wrapper">
+  {#if isLoading}
+    <div class="editor-loading">Loading...</div>
+  {:else}
+    <div class="editor-topbar">
+      <span class="wikilink-hint">Use [[page-slug]] to link to other lore pages</span>
+      {#if isSaving}
+        <span class="save-status saving">Saving...</span>
+      {:else}
+        <span class="save-status saved">Saved</span>
+      {/if}
+    </div>
+    <div class="editor-container" bind:this={editorContainer}></div>
+  {/if}
+</div>
+
+<style>
+  .editor-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--color-bg);
+  }
+
+  .editor-loading {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-faint);
+    font-family: var(--font-ui);
+    font-size: 13px;
+  }
+
+  .editor-topbar {
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-lg);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .wikilink-hint {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-text-faint);
+  }
+
+  .save-status { font-family: var(--font-ui); font-size: 11px; }
+  .save-status.saving { color: var(--color-accent); }
+  .save-status.saved  { color: var(--color-text-faint); }
+
+  .editor-container {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .editor-container :global(.cm-editor) { height: 100%; }
+</style>

--- a/src/renderer/src/components/LoreListSidebar.svelte
+++ b/src/renderer/src/components/LoreListSidebar.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { loreState, loadLore, createLorePage, deleteLorePage } from '../stores/lore'
+  import { appState } from '../stores/app'
+  import type { LoreMetadata } from '../env'
+
+  onMount(() => {
+    loadLore()
+  })
+
+  let isAdding = false
+  let newTitle = ''
+  let contextMenu: { x: number; y: number; page: LoreMetadata } | null = null
+
+  function handleAdd(): void {
+    isAdding = true
+    newTitle = ''
+  }
+
+  async function handleConfirmAdd(): Promise<void> {
+    if (newTitle.trim() === '') { isAdding = false; return }
+    const page = await createLorePage(newTitle.trim())
+    if (page) appState.update(s => ({ ...s, activeLoreId: page.id }))
+    isAdding = false
+    newTitle = ''
+  }
+
+  function handleCancelAdd(): void {
+    isAdding = false
+    newTitle = ''
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') handleConfirmAdd()
+    if (e.key === 'Escape') handleCancelAdd()
+  }
+
+  function handleContextMenu(e: MouseEvent, page: LoreMetadata): void {
+    contextMenu = { x: e.clientX, y: e.clientY, page }
+  }
+
+  function closeContextMenu(): void {
+    contextMenu = null
+  }
+</script>
+
+<div class="lore-sidebar">
+  <div class="sidebar-header">
+    <span class="sidebar-title">Lore</span>
+    <button class="btn-add" on:click={handleAdd} title="New lore page">+</button>
+  </div>
+
+  <div class="lore-list">
+    {#if $loreState.loading}
+      <div class="empty-state">Loading...</div>
+    {:else if $loreState.pages.length === 0 && !isAdding}
+      <div class="empty-state">
+        <p>No lore pages yet.</p>
+        <p>Click + to add your first entry.</p>
+      </div>
+    {:else}
+      {#each $loreState.pages as page (page.id)}
+        <div
+          class="lore-item"
+          class:active={$appState.activeLoreId === page.id}
+          on:click={() => appState.update(s => ({ ...s, activeLoreId: page.id }))}
+          on:contextmenu|preventDefault={(e) => handleContextMenu(e, page)}
+        >
+          <span class="lore-icon">📜</span>
+          <span class="lore-title">{page.title}</span>
+        </div>
+      {/each}
+    {/if}
+
+    {#if isAdding}
+      <div class="lore-input-row">
+        <input
+          type="text"
+          placeholder="Page title..."
+          bind:value={newTitle}
+          on:keydown={handleKeydown}
+          autofocus
+        />
+        <button class="btn-confirm" on:click={handleConfirmAdd}>✓</button>
+        <button class="btn-cancel" on:click={handleCancelAdd}>✕</button>
+      </div>
+    {/if}
+  </div>
+</div>
+
+{#if contextMenu}
+  <div class="context-backdrop" on:click={closeContextMenu}></div>
+  <div class="context-menu" style="left: {contextMenu.x}px; top: {contextMenu.y}px">
+    <button
+      class="context-item context-delete"
+      on:click={async () => {
+        const page = contextMenu?.page
+        contextMenu = null
+        if (page) {
+          if ($appState.activeLoreId === page.id) {
+            appState.update(s => ({ ...s, activeLoreId: null }))
+          }
+          await deleteLorePage(page.id)
+        }
+      }}
+    >
+      Delete "{contextMenu.page.title}"
+    </button>
+  </div>
+{/if}
+
+<style>
+  .lore-sidebar {
+    width: var(--sidebar-width);
+    height: 100%;
+    background: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .sidebar-header {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .sidebar-title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .btn-add {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    transition: all 0.15s;
+    line-height: 1;
+  }
+
+  .btn-add:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .lore-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-sm) 0;
+  }
+
+  .empty-state {
+    padding: var(--space-lg) var(--space-md);
+    text-align: center;
+    color: var(--color-text-faint);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  .empty-state p { margin: 0 0 4px; }
+
+  .lore-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background 0.1s;
+    border-left: 2px solid transparent;
+    user-select: none;
+  }
+
+  .lore-item:hover { background: var(--color-surface-hover); }
+
+  .lore-item.active {
+    background: var(--color-accent-subtle);
+    border-left-color: var(--color-accent);
+  }
+
+  .lore-icon { font-size: 14px; flex-shrink: 0; }
+
+  .lore-title {
+    flex: 1;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .lore-input-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 10px;
+  }
+
+  .lore-input-row input {
+    flex: 1;
+    background: var(--color-bg);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 5px 8px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 13px;
+    outline: none;
+  }
+
+  .btn-confirm, .btn-cancel {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: background 0.15s;
+    flex-shrink: 0;
+  }
+
+  .btn-confirm { color: var(--color-final); }
+  .btn-confirm:hover { background: var(--color-accent-subtle); }
+  .btn-cancel { color: var(--color-text-muted); }
+  .btn-cancel:hover { background: var(--color-surface-hover); }
+
+  .context-backdrop { position: fixed; inset: 0; z-index: 100; }
+
+  .context-menu {
+    position: fixed;
+    z-index: 101;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 4px;
+    min-width: 180px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .context-item {
+    width: 100%;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    text-align: left;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    cursor: pointer;
+    color: var(--color-text);
+  }
+
+  .context-delete { color: #e06c6c; }
+  .context-delete:hover { background: rgba(224, 108, 108, 0.1); }
+</style>

--- a/src/renderer/src/components/LoreMetadataPanel.svelte
+++ b/src/renderer/src/components/LoreMetadataPanel.svelte
@@ -1,0 +1,301 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { loreState } from '../stores/lore'
+  import type { LoreMetadata } from '../env'
+
+  export let loreId: string
+
+  $: page = $loreState.pages.find(p => p.id === loreId) ?? null
+
+  let backlinks: LoreMetadata[] = []
+  let loadingBacklinks = false
+
+  $: if (page) loadBacklinks(page.slug)
+
+  async function loadBacklinks(slug: string): Promise<void> {
+    loadingBacklinks = true
+    backlinks = await window.api.getLoreBacklinks(slug)
+    loadingBacklinks = false
+  }
+
+  async function updateField(
+    field: keyof LoreMetadata,
+    value: LoreMetadata[typeof field]
+  ): Promise<void> {
+    await window.api.updateLoreMetadata(loreId, { [field]: value })
+    loreState.update(s => ({
+      ...s,
+      pages: s.pages.map(p =>
+        p.id === loreId ? { ...p, [field]: value } : p
+      ).sort((a, b) => a.title.localeCompare(b.title))
+    }))
+  }
+
+  let newTag = ''
+
+  function handleTagKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') addTag()
+    if (e.key === 'Escape') newTag = ''
+  }
+
+  async function addTag(): Promise<void> {
+    const tag = newTag.trim().toLowerCase()
+    if (!tag || !page) return
+    if (page.tags.includes(tag)) { newTag = ''; return }
+    await updateField('tags', [...page.tags, tag])
+    newTag = ''
+  }
+
+  async function removeTag(tag: string): Promise<void> {
+    if (!page) return
+    await updateField('tags', page.tags.filter(t => t !== tag))
+  }
+
+  function navigateTo(targetId: string): void {
+    import('../stores/app').then(({ appState }) => {
+      appState.update(s => ({ ...s, activeLoreId: targetId }))
+    })
+  }
+</script>
+
+{#if page}
+  <div class="metadata-panel">
+    <div class="panel-header">
+      <span class="panel-title">Lore Info</span>
+    </div>
+
+    <div class="panel-body">
+
+      <div class="field">
+        <label for="lore-title">Title</label>
+        <input
+          id="lore-title"
+          type="text"
+          value={page.title}
+          on:change={(e) => updateField('title', e.currentTarget.value)}
+        />
+      </div>
+
+      <div class="field">
+        <label>Slug</label>
+        <span class="slug-value">{page.slug}</span>
+        <p class="field-hint">Use [[{page.slug}]] to link here from other lore pages</p>
+      </div>
+
+      <div class="field">
+        <label>Tags</label>
+        <div class="tags-container">
+          {#each page.tags as tag}
+            <span class="tag">
+              {tag}
+              <button class="tag-remove" on:click={() => removeTag(tag)}>×</button>
+            </span>
+          {/each}
+          <input
+            class="tag-input"
+            type="text"
+            placeholder="Add tag..."
+            bind:value={newTag}
+            on:keydown={handleTagKeydown}
+            on:blur={addTag}
+          />
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Backlinks</label>
+        {#if loadingBacklinks}
+          <p class="empty-hint">Loading...</p>
+        {:else if backlinks.length === 0}
+          <p class="empty-hint">No other lore pages link here yet.</p>
+        {:else}
+          <div class="backlink-list">
+            {#each backlinks as link}
+              <button
+                class="backlink-item"
+                on:click={() => navigateTo(link.id)}
+              >
+                <span class="backlink-icon">📜</span>
+                <span class="backlink-title">{link.title}</span>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+    </div>
+  </div>
+{/if}
+
+<style>
+  .metadata-panel {
+    width: 220px;
+    height: 100%;
+    background: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    overflow-y: auto;
+  }
+
+  .panel-header {
+    height: 36px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .panel-title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .panel-body {
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+  }
+
+  input {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 6px 8px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+  }
+
+  input:focus { border-color: var(--color-accent); }
+
+  .slug-value {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-accent);
+    background: var(--color-accent-subtle);
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .field-hint {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-text-faint);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .empty-hint {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--color-text-faint);
+    margin: 0;
+  }
+
+  .tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 4px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    min-height: 32px;
+    align-items: center;
+  }
+
+  .tags-container:focus-within { border-color: var(--color-accent); }
+
+  .tag {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px 6px;
+    background: var(--color-accent-subtle);
+    border: 1px solid var(--color-accent);
+    border-radius: 3px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--color-accent);
+  }
+
+  .tag-remove {
+    background: none;
+    border: none;
+    color: var(--color-accent);
+    cursor: pointer;
+    padding: 0;
+    font-size: 14px;
+    line-height: 1;
+    opacity: 0.7;
+  }
+
+  .tag-remove:hover { opacity: 1; }
+
+  .tag-input {
+    flex: 1;
+    min-width: 60px;
+    background: none;
+    border: none;
+    padding: 2px 4px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    outline: none;
+  }
+
+  .backlink-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .backlink-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: border-color 0.15s;
+    text-align: left;
+    width: 100%;
+  }
+
+  .backlink-item:hover { border-color: var(--color-accent); }
+  .backlink-icon { font-size: 12px; }
+
+  .backlink-title {
+    font-family: var(--font-ui);
+    font-size: 12px;
+    color: var(--color-text);
+  }
+</style>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
 
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
 
 declare global {
   interface Window {
@@ -44,8 +44,15 @@ declare global {
       openRecentProject(projectPath: string): Promise<ProjectMetadata | null>
       getProjectMetadata(): Promise<ProjectMetadata | null>
       updateProjectSettings(updates: Partial<ProjectMetadata>): Promise<boolean>
+      listLore(): Promise<LoreMetadata[]>
+      createLore(title: string): Promise<LoreMetadata | null>
+      readLore(loreId: string): Promise<string>
+      saveLore(loreId: string, content: string): Promise<boolean>
+      deleteLore(loreId: string): Promise<boolean>
+      updateLoreMetadata(loreId: string, updates: Partial<LoreMetadata>): Promise<boolean>
+      getLoreBacklinks(targetSlug: string): Promise<LoreMetadata[]>
     }
   }
 }
 
-export type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata }
+export type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata }

--- a/src/renderer/src/stores/app.ts
+++ b/src/renderer/src/stores/app.ts
@@ -10,6 +10,7 @@ interface AppState {
   activeSceneId: string | null
   activeCharacterId: string | null
   activeLocationId: string | null
+  activeLoreId: string | null
   projectMetadata: ProjectMetadata | null
 }
 
@@ -20,6 +21,7 @@ const initialState: AppState = {
   activeSceneId: null,
   activeCharacterId: null,
   activeLocationId: null,
+  activeLoreId: null,
   projectMetadata: null
 }
 
@@ -49,6 +51,7 @@ export function closeProject(): void {
     activeSceneId: null,
     activeCharacterId: null,
     activeLocationId: null,
+    activeLoreId: null,
     projectMetadata: null
   }))
 }

--- a/src/renderer/src/stores/lore.ts
+++ b/src/renderer/src/stores/lore.ts
@@ -1,0 +1,58 @@
+import { writable } from 'svelte/store'
+import type { LoreMetadata } from '../env'
+
+interface LoreState {
+  pages: LoreMetadata[]
+  loading: boolean
+}
+
+const initialState: LoreState = {
+  pages: [],
+  loading: false
+}
+
+export const loreState = writable<LoreState>(initialState)
+
+export async function loadLore(): Promise<void> {
+  loreState.update(s => ({ ...s, loading: true }))
+  try {
+    const pages = await window.api.listLore()
+    loreState.update(s => ({ ...s, pages, loading: false }))
+  } catch (error) {
+    console.error('Failed to load lore:', error)
+    loreState.update(s => ({ ...s, loading: false }))
+  }
+}
+
+export async function createLorePage(title: string): Promise<LoreMetadata | null> {
+  try {
+    const page = await window.api.createLore(title)
+    if (page) {
+      loreState.update(s => ({
+        ...s,
+        pages: [...s.pages, page].sort((a, b) => a.title.localeCompare(b.title))
+      }))
+      return page
+    }
+    return null
+  } catch (error) {
+    console.error('Failed to create lore page:', error)
+    return null
+  }
+}
+
+export async function deleteLorePage(id: string): Promise<void> {
+  try {
+    await window.api.deleteLore(id)
+    loreState.update(s => ({
+      ...s,
+      pages: s.pages.filter(p => p.id !== id)
+    }))
+  } catch (error) {
+    console.error('Failed to delete lore page:', error)
+  }
+}
+
+export function resetLore(): void {
+  loreState.set(initialState)
+}

--- a/src/renderer/src/views/WelcomeView.svelte
+++ b/src/renderer/src/views/WelcomeView.svelte
@@ -5,6 +5,7 @@
   import { loadCharacters } from '../stores/characters'
   import { loadLocations } from '../stores/locations'
   import NewProjectModal from '../components/NewProjectModal.svelte'
+  import { loadLore } from '../stores/lore'
 
   let showNewProjectModal = false
   let recentProjects: Array<{ path: string; title: string; lastOpened: string }> = []
@@ -17,7 +18,7 @@
     if (metadata) {
       setProject(metadata.id, metadata.title)
       setProjectMetadata(metadata)
-      await Promise.all([loadScenes(), loadCharacters(), loadLocations()])
+      await Promise.all([loadScenes(), loadCharacters(), loadLocations(), loadLore()])
       recentProjects = await window.api.getRecentProjects()
     }
   }


### PR DESCRIPTION
Closes #45 — Adds lore wiki section with list sidebar, Markdown editor, and metadata panel. [[wikilinks]] are highlighted in amber and clickable — navigating to lore pages, characters, or locations by slug (case-insensitive). Backlinks panel shows which lore pages link to the current one.