### PR TITLE
feat: add notes inbox with promote to scene, character, location, and…

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { autoUpdater } from 'electron-updater'
 import icon from '../../resources/icon.png?asset'
 import { ElectronAdapter } from '../../src-shared/storage/ElectronAdapter'
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata, NoteMetadata } from '../../src-shared/types'
 import { Document, Packer, Paragraph, TextRun, HeadingLevel, AlignmentType } from 'docx'
 
 
@@ -1400,6 +1400,339 @@ ipcMain.handle('lore:get-backlinks', async (
   } catch (error) {
     console.error('Failed to get backlinks:', error)
     return []
+  }
+})
+
+// ── Notes Handlers ────────────────────────────────────────────────────────────
+
+/** List all notes sorted by most recently updated */
+ipcMain.handle('notes:list', async (): Promise<NoteMetadata[]> => {
+  if (!currentProjectPath) return []
+
+  try {
+    const notesDir = join(currentProjectPath, 'notes')
+    const files = await adapter.listFiles(notesDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    const notes: NoteMetadata[] = []
+    for (const file of jsonFiles) {
+      try {
+        const raw = await adapter.readFile(file)
+        notes.push(JSON.parse(raw) as NoteMetadata)
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    return notes.sort((a, b) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )
+  } catch (error) {
+    console.error('Failed to list notes:', error)
+    return []
+  }
+})
+
+/** Create a new note */
+ipcMain.handle('notes:create', async (): Promise<NoteMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    const notesDir = join(currentProjectPath, 'notes')
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+
+    const metadata: NoteMetadata = {
+      id,
+      preview: 'New note',
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(notesDir, `${id}.md`), '')
+    await adapter.writeFile(
+      join(notesDir, `${id}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to create note:', error)
+    return null
+  }
+})
+
+/** Read a note's content */
+ipcMain.handle('notes:read', async (
+  _event,
+  noteId: string
+): Promise<string> => {
+  if (!currentProjectPath) return ''
+
+  try {
+    const mdPath = join(currentProjectPath, 'notes', `${noteId}.md`)
+    return await adapter.readFile(mdPath)
+  } catch (error) {
+    console.error('Failed to read note:', error)
+    return ''
+  }
+})
+
+/** Save a note's content and update its preview */
+ipcMain.handle('notes:save', async (
+  _event,
+  noteId: string,
+  content: string
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+
+  try {
+    const notesDir = join(currentProjectPath, 'notes')
+    const mdPath = join(notesDir, `${noteId}.md`)
+    const jsonPath = join(notesDir, `${noteId}.json`)
+
+    await adapter.writeFile(mdPath, content)
+
+    const raw = await adapter.readFile(jsonPath)
+    const metadata: NoteMetadata = JSON.parse(raw)
+
+    // Update preview from first non-empty line
+    const firstLine = content.split('\n').find(l => l.trim() !== '') ?? 'Empty note'
+    metadata.preview = firstLine.replace(/^#+\s+/, '').slice(0, 60)
+    metadata.updatedAt = new Date().toISOString()
+
+    await adapter.writeFile(jsonPath, JSON.stringify(metadata, null, 2))
+    return true
+  } catch (error) {
+    console.error('Failed to save note:', error)
+    return false
+  }
+})
+
+/** Delete a note */
+ipcMain.handle('notes:delete', async (
+  _event,
+  noteId: string
+): Promise<boolean> => {
+  if (!currentProjectPath) return false
+
+  try {
+    const notesDir = join(currentProjectPath, 'notes')
+    await adapter.deleteFile(join(notesDir, `${noteId}.md`))
+    await adapter.deleteFile(join(notesDir, `${noteId}.json`))
+    return true
+  } catch (error) {
+    console.error('Failed to delete note:', error)
+    return false
+  }
+})
+
+/** Promote a note to a scene */
+ipcMain.handle('notes:promote-to-scene', async (
+  _event,
+  noteId: string,
+  title: string
+): Promise<SceneMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    // Read note content
+    const content = await adapter.readFile(
+      join(currentProjectPath, 'notes', `${noteId}.md`)
+    )
+
+    // Create scene with note content
+    const scenesDir = join(currentProjectPath, 'scenes')
+    const existingFiles = await adapter.listFiles(scenesDir)
+    const existingCount = existingFiles.filter(f => f.endsWith('.json')).length
+
+    const baseSlug = slugify(title)
+    let slug = baseSlug
+    let counter = 1
+    while (await adapter.exists(join(scenesDir, `${slug}.json`))) {
+      slug = `${baseSlug}-${counter}`
+      counter++
+    }
+
+    const now = new Date().toISOString()
+    const metadata: SceneMetadata = {
+      id: crypto.randomUUID(),
+      title,
+      order: existingCount + 1,
+      act: 1,
+      chapter: null,
+      status: 'draft',
+      pov: null,
+      characters: [],
+      location: null,
+      inWorldDate: null,
+      tags: [],
+      wordCount: content.trim() === '' ? 0 : content.trim().split(/\s+/).length,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(scenesDir, `${slug}.md`), content)
+    await adapter.writeFile(
+      join(scenesDir, `${slug}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    // Delete the note
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.md`))
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.json`))
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to promote note to scene:', error)
+    return null
+  }
+})
+
+/** Promote a note to a character */
+ipcMain.handle('notes:promote-to-character', async (
+  _event,
+  noteId: string,
+  name: string
+): Promise<CharacterMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    const content = await adapter.readFile(
+      join(currentProjectPath, 'notes', `${noteId}.md`)
+    )
+
+    const charactersDir = join(currentProjectPath, 'characters')
+    const baseSlug = slugify(name)
+    let slug = baseSlug
+    let counter = 1
+    while (await adapter.exists(join(charactersDir, `${slug}.json`))) {
+      slug = `${baseSlug}-${counter}`
+      counter++
+    }
+
+    const now = new Date().toISOString()
+    const metadata: CharacterMetadata = {
+      id: crypto.randomUUID(),
+      slug,
+      name,
+      aliases: [],
+      tags: [],
+      firstAppearance: null,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(charactersDir, `${slug}.md`), content || `# ${name}\n\n`)
+    await adapter.writeFile(
+      join(charactersDir, `${slug}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.md`))
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.json`))
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to promote note to character:', error)
+    return null
+  }
+})
+
+/** Promote a note to a location */
+ipcMain.handle('notes:promote-to-location', async (
+  _event,
+  noteId: string,
+  name: string
+): Promise<LocationMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    const content = await adapter.readFile(
+      join(currentProjectPath, 'notes', `${noteId}.md`)
+    )
+
+    const locationsDir = join(currentProjectPath, 'locations')
+    const baseSlug = slugify(name)
+    let slug = baseSlug
+    let counter = 1
+    while (await adapter.exists(join(locationsDir, `${slug}.json`))) {
+      slug = `${baseSlug}-${counter}`
+      counter++
+    }
+
+    const now = new Date().toISOString()
+    const metadata: LocationMetadata = {
+      id: crypto.randomUUID(),
+      slug,
+      name,
+      tags: [],
+      mapImage: null,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(locationsDir, `${slug}.md`), content || `# ${name}\n\n`)
+    await adapter.writeFile(
+      join(locationsDir, `${slug}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.md`))
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.json`))
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to promote note to location:', error)
+    return null
+  }
+})
+
+/** Promote a note to a lore page */
+ipcMain.handle('notes:promote-to-lore', async (
+  _event,
+  noteId: string,
+  title: string
+): Promise<LoreMetadata | null> => {
+  if (!currentProjectPath) return null
+
+  try {
+    const content = await adapter.readFile(
+      join(currentProjectPath, 'notes', `${noteId}.md`)
+    )
+
+    const loreDir = join(currentProjectPath, 'lore')
+    const baseSlug = slugify(title)
+    let slug = baseSlug
+    let counter = 1
+    while (await adapter.exists(join(loreDir, `${slug}.json`))) {
+      slug = `${baseSlug}-${counter}`
+      counter++
+    }
+
+    const now = new Date().toISOString()
+    const metadata: LoreMetadata = {
+      id: crypto.randomUUID(),
+      slug,
+      title,
+      tags: [],
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await adapter.writeFile(join(loreDir, `${slug}.md`), content || `# ${title}\n\n`)
+    await adapter.writeFile(
+      join(loreDir, `${slug}.json`),
+      JSON.stringify(metadata, null, 2)
+    )
+
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.md`))
+    await adapter.deleteFile(join(currentProjectPath, 'notes', `${noteId}.json`))
+
+    return metadata
+  } catch (error) {
+    console.error('Failed to promote note to lore:', error)
+    return null
   }
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata, NoteMetadata } from '../../src-shared/types'
 
 const api = {
   openProject: (): Promise<ProjectMetadata | null> =>
@@ -115,6 +115,33 @@ const api = {
 
   getLoreBacklinks: (targetSlug: string): Promise<LoreMetadata[]> =>
     ipcRenderer.invoke('lore:get-backlinks', targetSlug),
+
+  listNotes: (): Promise<NoteMetadata[]> =>
+    ipcRenderer.invoke('notes:list'),
+
+  createNote: (): Promise<NoteMetadata | null> =>
+    ipcRenderer.invoke('notes:create'),
+
+  readNote: (noteId: string): Promise<string> =>
+    ipcRenderer.invoke('notes:read', noteId),
+
+  saveNote: (noteId: string, content: string): Promise<boolean> =>
+    ipcRenderer.invoke('notes:save', noteId, content),
+
+  deleteNote: (noteId: string): Promise<boolean> =>
+    ipcRenderer.invoke('notes:delete', noteId),
+
+  promoteToScene: (noteId: string, title: string): Promise<SceneMetadata | null> =>
+    ipcRenderer.invoke('notes:promote-to-scene', noteId, title),
+
+  promoteToCharacter: (noteId: string, name: string): Promise<CharacterMetadata | null> =>
+    ipcRenderer.invoke('notes:promote-to-character', noteId, name),
+
+  promoteToLocation: (noteId: string, name: string): Promise<LocationMetadata | null> =>
+    ipcRenderer.invoke('notes:promote-to-location', noteId, name),
+
+  promoteToLore: (noteId: string, title: string): Promise<LoreMetadata | null> =>
+    ipcRenderer.invoke('notes:promote-to-lore', noteId, title),
 }
 
 if (process.contextIsolated) {

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -23,12 +23,15 @@
   import LoreEditor from './components/LoreEditor.svelte'
   import LoreMetadataPanel from './components/LoreMetadataPanel.svelte'
   import { resetLore } from './stores/lore'
+  import NotesView from './views/NotesView.svelte'
+  import { resetNotes } from './stores/notes'
 
   function handleCloseProject(): void {
     resetScenes()
     resetCharacters()
     resetLocations()
     resetLore()
+    resetNotes()
     closeProject()
   }
 
@@ -102,7 +105,9 @@
           {:else if $appState.activeSection === 'plot'}
             <PlotBoardView /> 
           {:else if $appState.activeSection === 'timeline'}
-            <TimelineView /> 
+            <TimelineView />
+          {:else if $appState.activeSection === 'notes'}
+            <NotesView />
           {:else if $appState.activeSection === 'characters'}
             {#if $appState.activeCharacterId}
               {#key $appState.activeCharacterId}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
 
-import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata } from '../../src-shared/types'
+import type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata, NoteMetadata } from '../../src-shared/types'
 
 declare global {
   interface Window {
@@ -51,8 +51,17 @@ declare global {
       deleteLore(loreId: string): Promise<boolean>
       updateLoreMetadata(loreId: string, updates: Partial<LoreMetadata>): Promise<boolean>
       getLoreBacklinks(targetSlug: string): Promise<LoreMetadata[]>
+      listNotes(): Promise<NoteMetadata[]>
+      createNote(): Promise<NoteMetadata | null>
+      readNote(noteId: string): Promise<string>
+      saveNote(noteId: string, content: string): Promise<boolean>
+      deleteNote(noteId: string): Promise<boolean>
+      promoteToScene(noteId: string, title: string): Promise<SceneMetadata | null>
+      promoteToCharacter(noteId: string, name: string): Promise<CharacterMetadata | null>
+      promoteToLocation(noteId: string, name: string): Promise<LocationMetadata | null>
+      promoteToLore(noteId: string, title: string): Promise<LoreMetadata | null>
     }
   }
 }
 
-export type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata }
+export type { ProjectMetadata, SceneMetadata, CharacterMetadata, LocationMetadata, LoreMetadata, NoteMetadata }

--- a/src/renderer/src/stores/notes.ts
+++ b/src/renderer/src/stores/notes.ts
@@ -1,0 +1,54 @@
+import { writable } from 'svelte/store'
+import type { NoteMetadata } from '../env'
+
+interface NotesState {
+  notes: NoteMetadata[]
+  loading: boolean
+}
+
+const initialState: NotesState = {
+  notes: [],
+  loading: false
+}
+
+export const notesState = writable<NotesState>(initialState)
+
+export async function loadNotes(): Promise<void> {
+  notesState.update(s => ({ ...s, loading: true }))
+  try {
+    const notes = await window.api.listNotes()
+    notesState.update(s => ({ ...s, notes, loading: false }))
+  } catch (error) {
+    console.error('Failed to load notes:', error)
+    notesState.update(s => ({ ...s, loading: false }))
+  }
+}
+
+export async function createNote(): Promise<NoteMetadata | null> {
+  try {
+    const note = await window.api.createNote()
+    if (note) {
+      notesState.update(s => ({ ...s, notes: [note, ...s.notes] }))
+      return note
+    }
+    return null
+  } catch (error) {
+    console.error('Failed to create note:', error)
+    return null
+  }
+}
+
+export function removeNoteFromStore(id: string): void {
+  notesState.update(s => ({ ...s, notes: s.notes.filter(n => n.id !== id) }))
+}
+
+export function updateNotePreview(id: string, preview: string): void {
+  notesState.update(s => ({
+    ...s,
+    notes: s.notes.map(n => n.id === id ? { ...n, preview } : n)
+  }))
+}
+
+export function resetNotes(): void {
+  notesState.set(initialState)
+}

--- a/src/renderer/src/views/NotesView.svelte
+++ b/src/renderer/src/views/NotesView.svelte
@@ -1,0 +1,581 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import { EditorState } from '@codemirror/state'
+  import { EditorView, keymap, drawSelection } from '@codemirror/view'
+  import { defaultKeymap, historyKeymap, history } from '@codemirror/commands'
+  import { markdown } from '@codemirror/lang-markdown'
+  import { languages } from '@codemirror/language-data'
+  import {
+    notesState, loadNotes, createNote,
+    removeNoteFromStore, updateNotePreview
+  } from '../stores/notes'
+  import { scenesState } from '../stores/scenes'
+  import { charactersState } from '../stores/characters'
+  import { locationsState } from '../stores/locations'
+  import { loreState } from '../stores/lore'
+  import { appState, setActiveSection, setActiveScene } from '../stores/app'
+  import type { NoteMetadata } from '../env'
+
+  onMount(() => { loadNotes() })
+
+  let activeNoteId: string | null = null
+  let editorContainer: HTMLDivElement
+  let editorView: EditorView | null = null
+  let saveTimeout: ReturnType<typeof setTimeout> | null = null
+  let isSaving = false
+  let isLoading = false
+  let showPromoteMenu = false
+  let promoteTitle = ''
+  let promoteType: 'scene' | 'character' | 'location' | 'lore' | null = null
+
+  $: activeNote = $notesState.notes.find(n => n.id === activeNoteId) ?? null
+
+  const AUTOSAVE_DELAY_MS = 2000
+
+  const quilltoriumTheme = EditorView.theme({
+    '&': {
+      height: '100%',
+      fontSize: '16px',
+      fontFamily: 'var(--font-display)',
+      backgroundColor: 'transparent',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
+      padding: '24px 0',
+      fontFamily: 'var(--font-display)',
+      lineHeight: '1.8',
+    },
+    '.cm-content': {
+      maxWidth: '600px',
+      margin: '0 auto',
+      padding: '0 24px',
+      caretColor: 'var(--color-accent)',
+      color: 'var(--color-text)',
+    },
+    '.cm-focused': { outline: 'none' },
+    '.cm-line': { padding: '0' },
+    '.cm-cursor': {
+      borderLeftColor: 'var(--color-accent)',
+      borderLeftWidth: '2px',
+    },
+    '.cm-selectionBackground': {
+      backgroundColor: 'var(--color-accent-subtle) !important',
+    },
+    '.cm-gutters': { display: 'none' },
+  }, { dark: true })
+
+  function scheduleSave(content: string): void {
+    if (!activeNoteId) return
+    if (saveTimeout) clearTimeout(saveTimeout)
+    const firstLine = content.split('\n').find(l => l.trim() !== '') ?? 'Empty note'
+    const preview = firstLine.replace(/^#+\s+/, '').slice(0, 60)
+    updateNotePreview(activeNoteId, preview)
+    saveTimeout = setTimeout(async () => {
+      if (!activeNoteId) return
+      isSaving = true
+      await window.api.saveNote(activeNoteId, content)
+      isSaving = false
+    }, AUTOSAVE_DELAY_MS)
+  }
+
+  async function selectNote(note: NoteMetadata): Promise<void> {
+    if (saveTimeout) clearTimeout(saveTimeout)
+    editorView?.destroy()
+    editorView = null
+    activeNoteId = note.id
+    isLoading = true
+    showPromoteMenu = false
+
+    const content = await window.api.readNote(note.id)
+    isLoading = false
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    if (!editorContainer) return
+
+    const state = EditorState.create({
+      doc: content,
+      extensions: [
+        history(),
+        drawSelection(),
+        markdown({ codeLanguages: languages }),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        quilltoriumTheme,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) scheduleSave(update.state.doc.toString())
+        }),
+        EditorView.lineWrapping,
+      ]
+    })
+
+    editorView = new EditorView({ state, parent: editorContainer })
+    editorView.focus()
+  }
+
+  async function handleNewNote(): Promise<void> {
+    const note = await createNote()
+    if (note) await selectNote(note)
+  }
+
+  async function handleDeleteNote(): Promise<void> {
+    if (!activeNoteId) return
+    const id = activeNoteId
+    editorView?.destroy()
+    editorView = null
+    activeNoteId = null
+    await window.api.deleteNote(id)
+    removeNoteFromStore(id)
+  }
+
+  function startPromote(type: typeof promoteType): void {
+    promoteType = type
+    promoteTitle = activeNote?.preview ?? ''
+    showPromoteMenu = false
+  }
+
+  async function confirmPromote(): Promise<void> {
+    if (!activeNoteId || !promoteType || !promoteTitle.trim()) return
+    const id = activeNoteId
+    const title = promoteTitle.trim()
+
+    editorView?.destroy()
+    editorView = null
+    activeNoteId = null
+
+    if (promoteType === 'scene') {
+      const scene = await window.api.promoteToScene(id, title)
+      if (scene) {
+        scenesState.update(s => ({
+          ...s,
+          scenes: [...s.scenes, scene].sort((a, b) => a.order - b.order)
+        }))
+        removeNoteFromStore(id)
+        setActiveSection('scenes')
+        setActiveScene(scene.id)
+      }
+    } else if (promoteType === 'character') {
+      const character = await window.api.promoteToCharacter(id, title)
+      if (character) {
+        charactersState.update(s => ({
+          ...s,
+          characters: [...s.characters, character].sort((a, b) =>
+            a.name.localeCompare(b.name))
+        }))
+        removeNoteFromStore(id)
+        appState.update(s => ({ ...s, activeSection: 'characters', activeCharacterId: character.id }))
+      }
+    } else if (promoteType === 'location') {
+      const location = await window.api.promoteToLocation(id, title)
+      if (location) {
+        locationsState.update(s => ({
+          ...s,
+          locations: [...s.locations, location].sort((a, b) =>
+            a.name.localeCompare(b.name))
+        }))
+        removeNoteFromStore(id)
+        appState.update(s => ({ ...s, activeSection: 'locations', activeLocationId: location.id }))
+      }
+    } else if (promoteType === 'lore') {
+      const page = await window.api.promoteToLore(id, title)
+      if (page) {
+        loreState.update(s => ({
+          ...s,
+          pages: [...s.pages, page].sort((a, b) => a.title.localeCompare(b.title))
+        }))
+        removeNoteFromStore(id)
+        appState.update(s => ({ ...s, activeSection: 'lore', activeLoreId: page.id }))
+      }
+    }
+
+    promoteType = null
+    promoteTitle = ''
+  }
+
+  function formatDate(iso: string): string {
+    const date = new Date(iso)
+    const now = new Date()
+    const diff = now.getTime() - date.getTime()
+    const hours = Math.floor(diff / (1000 * 60 * 60))
+    if (hours < 1) return 'Just now'
+    if (hours < 24) return `${hours}h ago`
+    const days = Math.floor(hours / 24)
+    if (days === 1) return 'Yesterday'
+    if (days < 7) return `${days}d ago`
+    return date.toLocaleDateString()
+  }
+
+  onDestroy(() => {
+    if (saveTimeout) clearTimeout(saveTimeout)
+    editorView?.destroy()
+  })
+</script>
+
+<div class="notes-view">
+  <!-- Notes list sidebar -->
+  <div class="notes-sidebar">
+    <div class="sidebar-header">
+      <span class="sidebar-title">Notes</span>
+      <button class="btn-add" on:click={handleNewNote} title="New note">+</button>
+    </div>
+
+    <div class="notes-list">
+      {#if $notesState.loading}
+        <div class="empty-state">Loading...</div>
+      {:else if $notesState.notes.length === 0}
+        <div class="empty-state">
+          <p>No notes yet.</p>
+          <p>Click + to capture a quick idea.</p>
+        </div>
+      {:else}
+        {#each $notesState.notes as note (note.id)}
+          <div
+            class="note-item"
+            class:active={activeNoteId === note.id}
+            on:click={() => selectNote(note)}
+          >
+            <span class="note-preview">{note.preview}</span>
+            <span class="note-date">{formatDate(note.updatedAt)}</span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </div>
+
+  <!-- Note editor -->
+  <div class="note-editor">
+    {#if !activeNoteId}
+      <div class="editor-placeholder">
+        Select a note or click + to capture a new idea
+      </div>
+    {:else if isLoading}
+      <div class="editor-placeholder">Loading...</div>
+    {:else}
+      <div class="note-toolbar">
+        <div class="toolbar-left">
+          {#if isSaving}
+            <span class="save-status saving">Saving...</span>
+          {:else}
+            <span class="save-status saved">Saved</span>
+          {/if}
+        </div>
+        <div class="toolbar-right">
+          <!-- Promote menu -->
+          <div class="promote-container">
+            <button
+              class="btn-promote"
+              on:click={() => showPromoteMenu = !showPromoteMenu}
+            >
+              Promote to... ▾
+            </button>
+            {#if showPromoteMenu}
+              <div class="promote-backdrop" on:click={() => showPromoteMenu = false}></div>
+              <div class="promote-menu">
+                <button class="promote-item" on:click={() => startPromote('scene')}>📄 Scene</button>
+                <button class="promote-item" on:click={() => startPromote('character')}>👤 Character</button>
+                <button class="promote-item" on:click={() => startPromote('location')}>🗺️ Location</button>
+                <button class="promote-item" on:click={() => startPromote('lore')}>📚 Lore Page</button>
+              </div>
+            {/if}
+          </div>
+          <button class="btn-delete" on:click={handleDeleteNote} title="Delete note">🗑</button>
+        </div>
+      </div>
+
+      <!-- Promote dialog -->
+      {#if promoteType}
+        <div class="promote-dialog">
+          <span class="promote-label">
+            Promoting to {promoteType} —
+            {promoteType === 'scene' ? 'Scene title' : 'Name'}:
+          </span>
+          <input
+            type="text"
+            bind:value={promoteTitle}
+            on:keydown={(e) => { if (e.key === 'Enter') confirmPromote() }}
+            autofocus
+          />
+          <button class="btn-confirm-promote" on:click={confirmPromote}>
+            Promote
+          </button>
+          <button class="btn-cancel-promote" on:click={() => promoteType = null}>
+            Cancel
+          </button>
+        </div>
+      {/if}
+
+      <div class="editor-container" bind:this={editorContainer}></div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .notes-view {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    background: var(--color-bg);
+  }
+
+  .notes-sidebar {
+    width: var(--sidebar-width);
+    height: 100%;
+    background: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .sidebar-header {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .sidebar-title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .btn-add {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    transition: all 0.15s;
+    line-height: 1;
+  }
+
+  .btn-add:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+
+  .notes-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-sm) 0;
+  }
+
+  .empty-state {
+    padding: var(--space-lg) var(--space-md);
+    text-align: center;
+    color: var(--color-text-faint);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  .empty-state p { margin: 0 0 4px; }
+
+  .note-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: background 0.1s;
+    border-left: 2px solid transparent;
+  }
+
+  .note-item:hover { background: var(--color-surface-hover); }
+
+  .note-item.active {
+    background: var(--color-accent-subtle);
+    border-left-color: var(--color-accent);
+  }
+
+  .note-preview {
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .note-date {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-text-faint);
+  }
+
+  .note-editor {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .editor-placeholder {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-faint);
+    font-family: var(--font-ui);
+    font-size: 13px;
+  }
+
+  .note-toolbar {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-lg);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .toolbar-left, .toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .save-status { font-family: var(--font-ui); font-size: 11px; }
+  .save-status.saving { color: var(--color-accent); }
+  .save-status.saved { color: var(--color-text-faint); }
+
+  .promote-container { position: relative; }
+
+  .btn-promote {
+    padding: 5px 12px;
+    background: var(--color-accent-subtle);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    color: var(--color-accent);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .btn-promote:hover {
+    background: var(--color-accent);
+    color: #1a1a1f;
+  }
+
+  .promote-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+  }
+
+  .promote-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 101;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 4px;
+    min-width: 160px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .promote-item {
+    width: 100%;
+    padding: 8px 12px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    text-align: left;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .promote-item:hover { background: var(--color-surface-hover); }
+
+  .btn-delete {
+    background: none;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background 0.15s;
+    opacity: 0.6;
+  }
+
+  .btn-delete:hover { background: rgba(224, 108, 108, 0.15); opacity: 1; }
+
+  .promote-dialog {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 8px var(--space-lg);
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .promote-label {
+    font-family: var(--font-ui);
+    font-size: 12px;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+
+  .promote-dialog input {
+    flex: 1;
+    background: var(--color-bg);
+    border: 1px solid var(--color-accent);
+    border-radius: 4px;
+    padding: 5px 8px;
+    color: var(--color-text);
+    font-family: var(--font-ui);
+    font-size: 13px;
+    outline: none;
+  }
+
+  .btn-confirm-promote {
+    padding: 5px 12px;
+    background: var(--color-accent);
+    color: #1a1a1f;
+    border: none;
+    border-radius: 4px;
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .btn-cancel-promote {
+    padding: 5px 12px;
+    background: none;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-family: var(--font-ui);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .editor-container {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .editor-container :global(.cm-editor) { height: 100%; }
+</style>

--- a/src/renderer/src/views/WelcomeView.svelte
+++ b/src/renderer/src/views/WelcomeView.svelte
@@ -6,6 +6,7 @@
   import { loadLocations } from '../stores/locations'
   import NewProjectModal from '../components/NewProjectModal.svelte'
   import { loadLore } from '../stores/lore'
+  import { loadNotes } from '../stores/notes'
 
   let showNewProjectModal = false
   let recentProjects: Array<{ path: string; title: string; lastOpened: string }> = []
@@ -18,7 +19,7 @@
     if (metadata) {
       setProject(metadata.id, metadata.title)
       setProjectMetadata(metadata)
-      await Promise.all([loadScenes(), loadCharacters(), loadLocations(), loadLore()])
+      await Promise.all([loadScenes(), loadCharacters(), loadLocations(), loadLore(), loadNotes()])
       recentProjects = await window.api.getRecentProjects()
     }
   }


### PR DESCRIPTION
Closes #46 — Adds notes inbox with quick capture, autosave, and promote functionality. Notes can be promoted to scenes, characters, locations, or lore pages — content is carried over and the note is deleted. Notes sorted by most recently updated.